### PR TITLE
Chirp Feed Screen

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,4 +1,5 @@
 import 'package:academia/config/router/router.dart';
+import 'package:academia/features/chirp/presentation/bloc/feed/feed_bloc.dart';
 import 'package:academia/features/features.dart';
 import 'package:academia/injection_container.dart';
 import 'package:dynamic_color/dynamic_color.dart';
@@ -62,6 +63,9 @@ class _AcademiaState extends State<Academia> {
             getPreviousAuthState: sl.get<GetPreviousAuthState>(),
             signInWithGoogle: sl.get<SignInWithGoogleUsecase>(),
           )..add(AuthCheckStatusEvent()),
+        ),
+        BlocProvider(
+          create: (context) => sl<FeedBloc>()..add(LoadFeedEvent()),
         ),
       ],
       child: DynamicColorBuilder(

--- a/lib/config/router/routes.dart
+++ b/lib/config/router/routes.dart
@@ -1,3 +1,4 @@
+import 'package:academia/features/chirp/presentation/views/feed_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:academia/features/features.dart';
@@ -34,7 +35,7 @@ class MainLayoutShellRoute extends ShellRouteData {
 class HomeRoute extends GoRouteData with _$HomeRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return Scaffold(body: Center(child: Text("Chirp")));
+    return FeedPage();
   }
 }
 
@@ -89,3 +90,4 @@ class CompleteProfileRoute extends GoRouteData with _$CompleteProfileRoute {
     return CompleteProfileScreen();
   }
 }
+

--- a/lib/features/chirp/data/datasources/chirp_remote_data_source.dart
+++ b/lib/features/chirp/data/datasources/chirp_remote_data_source.dart
@@ -1,0 +1,76 @@
+import 'package:academia/features/chirp/data/models/post_model.dart';
+
+abstract class ChirpRemoteDataSource {
+  Future<List<PostModel>> getFeedPosts();
+}
+
+class ChirpRemoteDataSourceImpl implements ChirpRemoteDataSource {
+  @override
+  Future<List<PostModel>> getFeedPosts() async {
+    await Future.delayed(Duration(milliseconds: 500));
+    return [
+      PostModel(
+        id: '1',
+        title: 'Welcome to c/flutter',
+        content:
+            'This is your first post! Feel free to ask questions, share your progress, or explore widgets and state management tips with others in the Flutter community.',
+        communityName: 'flutter',
+        upvotes: 123,
+        comments: 4,
+        imageUrl: null,
+      ),
+      PostModel(
+        id: '2',
+        title: 'Top 10 tips for learning Dart',
+        content:
+            'If you\'re new to Dart, start with understanding the type system, then focus on collections (List, Set, Map). Learn how async/await works—it’s crucial for Flutter apps.',
+        communityName: 'dartlang',
+        upvotes: 210,
+        comments: 12,
+        imageUrl: null,
+      ),
+      PostModel(
+        id: '3',
+        title: 'Showcase: My portfolio built in Flutter Web!',
+        content:
+            'Spent the last 3 weeks building my portfolio using Flutter Web. It’s hosted on Firebase, uses Riverpod for state management, and looks great on both desktop and mobile. Check it out!',
+        communityName: 'flutterdev',
+        upvotes: 430,
+        comments: 38,
+        imageUrl:
+            'https://strapi.dhiwise.com/uploads/mastering_flutter_release_on_android_ios_and_web_2_ffa2ce3b59.jpg',
+      ),
+      PostModel(
+        id: '4',
+        title: 'Why I switched from React Native to Flutter',
+        content:
+            'After two years of RN, I tried Flutter for a side project. The setup was cleaner, hot reload was faster, and widget composition just made sense. Here’s my full story and benchmarks...',
+        communityName: 'mobiledev',
+        upvotes: 332,
+        comments: 27,
+        imageUrl: null,
+      ),
+      PostModel(
+        id: '5',
+        title: 'Can someone explain BLoC vs Riverpod?',
+        content:
+            'I\'m learning state management and got stuck between choosing BLoC and Riverpod. BLoC seems verbose but structured; Riverpod is more concise but has its own learning curve. Which one scales better?',
+        communityName: 'flutterhelp',
+        upvotes: 156,
+        comments: 19,
+        imageUrl: null,
+      ),
+      PostModel(
+        id: '6',
+        title: 'Building a social media app clone in Flutter',
+        content:
+            'Started working on a Twitter/Reddit hybrid using Flutter + Firebase. Using Cloud Firestore for posts, Firebase Auth for login, and Riverpod for state. Open-source repo coming soon!',
+        communityName: 'devlogs',
+        upvotes: 499,
+        comments: 88,
+        imageUrl:
+            'https://strapi.dhiwise.com/uploads/mastering_flutter_release_on_android_ios_and_web_2_ffa2ce3b59.jpg',
+      ),
+    ];
+  }
+}

--- a/lib/features/chirp/data/models/post_model.dart
+++ b/lib/features/chirp/data/models/post_model.dart
@@ -1,0 +1,25 @@
+import 'package:academia/features/chirp/domain/entities/post.dart';
+
+class PostModel extends Post {
+  PostModel({
+    required super.id,
+    required super.title,
+    required super.content,
+    required super.communityName,
+    required super.upvotes,
+    required super.comments,
+    super.imageUrl,
+  });
+
+  factory PostModel.fromJson(Map<String, dynamic> json) {
+    return PostModel(
+      id: json['id'],
+      title: json['title'],
+      content: json['content'],
+      communityName: json['communityName'],
+      upvotes: json['upvotes'],
+      comments: json['comments'],
+      imageUrl: json['imageUrl'],
+    );
+  }
+}

--- a/lib/features/chirp/data/repositories/chirp_repository_impl.dart
+++ b/lib/features/chirp/data/repositories/chirp_repository_impl.dart
@@ -1,0 +1,14 @@
+import 'package:academia/features/chirp/data/datasources/chirp_remote_data_source.dart';
+import 'package:academia/features/chirp/domain/entities/post.dart';
+import 'package:academia/features/chirp/domain/repositories/chirp_repository.dart';
+
+class ChirpRepositoryImpl implements ChirpRepository {
+  final ChirpRemoteDataSource remoteDataSource;
+
+  ChirpRepositoryImpl(this.remoteDataSource);
+
+  @override
+  Future<List<Post>> getFeedPosts() async {
+    return await remoteDataSource.getFeedPosts();
+  }
+}

--- a/lib/features/chirp/domain/entities/post.dart
+++ b/lib/features/chirp/domain/entities/post.dart
@@ -1,0 +1,19 @@
+class Post {
+  final String id;
+  final String title;
+  final String content;
+  final String communityName;
+  final int upvotes;
+  final int comments;
+  final String? imageUrl;
+
+  Post({
+    required this.id,
+    required this.title,
+    required this.content,
+    required this.communityName,
+    required this.upvotes,
+    required this.comments,
+    this.imageUrl,
+  });
+}

--- a/lib/features/chirp/domain/repositories/chirp_repository.dart
+++ b/lib/features/chirp/domain/repositories/chirp_repository.dart
@@ -1,0 +1,5 @@
+import 'package:academia/features/chirp/domain/entities/post.dart';
+
+abstract class ChirpRepository {
+  Future<List<Post>> getFeedPosts();
+}

--- a/lib/features/chirp/domain/usecases/get_feed_posts.dart
+++ b/lib/features/chirp/domain/usecases/get_feed_posts.dart
@@ -1,0 +1,12 @@
+import 'package:academia/features/chirp/domain/entities/post.dart';
+import 'package:academia/features/chirp/domain/repositories/chirp_repository.dart';
+
+class GetFeedPosts {
+  final ChirpRepository repository;
+
+  GetFeedPosts(this.repository);
+
+  Future<List<Post>> call() async {
+    return await repository.getFeedPosts();
+  }
+}

--- a/lib/features/chirp/presentation/bloc/feed/feed_bloc.dart
+++ b/lib/features/chirp/presentation/bloc/feed/feed_bloc.dart
@@ -1,0 +1,20 @@
+import 'package:academia/features/chirp/domain/entities/post.dart';
+import 'package:academia/features/chirp/domain/usecases/get_feed_posts.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+part 'feed_event.dart';
+part 'feed_state.dart';
+
+class FeedBloc extends Bloc<FeedEvent, FeedState> {
+  final GetFeedPosts getFeedPosts;
+
+  FeedBloc(this.getFeedPosts) : super(FeedLoading()) {
+    on<LoadFeedEvent>((event, emit) async {
+      emit(FeedLoading());
+      final posts = await getFeedPosts();
+      emit(FeedLoaded(posts));
+    });
+  }
+}
+

--- a/lib/features/chirp/presentation/bloc/feed/feed_event.dart
+++ b/lib/features/chirp/presentation/bloc/feed/feed_event.dart
@@ -1,0 +1,9 @@
+part of 'feed_bloc.dart';
+
+
+abstract class FeedEvent extends Equatable {
+  @override
+  List<Object> get props => [];
+}
+
+class LoadFeedEvent extends FeedEvent {}

--- a/lib/features/chirp/presentation/bloc/feed/feed_state.dart
+++ b/lib/features/chirp/presentation/bloc/feed/feed_state.dart
@@ -1,0 +1,16 @@
+part of 'feed_bloc.dart';
+
+abstract class FeedState extends Equatable {
+  @override
+  List<Object> get props => [];
+}
+
+class FeedLoading extends FeedState {}
+
+class FeedLoaded extends FeedState {
+  final List<Post> posts;
+  FeedLoaded(this.posts);
+
+  @override
+  List<Object> get props => [posts];
+}

--- a/lib/features/chirp/presentation/views/feed_screen.dart
+++ b/lib/features/chirp/presentation/views/feed_screen.dart
@@ -1,0 +1,30 @@
+import 'package:academia/features/chirp/presentation/bloc/feed/feed_bloc.dart';
+import 'package:academia/features/chirp/presentation/widgets/post_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class FeedPage extends StatelessWidget {
+  const FeedPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Chirp'), centerTitle: true),
+      body: BlocBuilder<FeedBloc, FeedState>(
+        builder: (context, state) {
+          if (state is FeedLoading) {
+            return Center(child: CircularProgressIndicator());
+          } else if (state is FeedLoaded) {
+            return ListView.builder(
+              itemCount: state.posts.length,
+              itemBuilder: (context, index) =>
+                  PostCard(post: state.posts[index]),
+            );
+          } else {
+            return Center(child: Text('Something went wrong'));
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/chirp/presentation/widgets/post_card.dart
+++ b/lib/features/chirp/presentation/widgets/post_card.dart
@@ -1,0 +1,57 @@
+import 'package:academia/features/chirp/domain/entities/post.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+class PostCard extends StatelessWidget {
+  final Post post;
+  const PostCard({super.key, required this.post});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {},
+      child: Card(
+        margin: EdgeInsets.all(8),
+        child: Padding(
+          padding: EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'c/${post.communityName}',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              SizedBox(height: 8),
+              Text(post.title, style: TextStyle(fontSize: 18)),
+              if (post.imageUrl != null) ...[
+                SizedBox(height: 8),
+                ConstrainedBox(
+                  constraints: BoxConstraints(minWidth: double.infinity),
+                  child: CachedNetworkImage(
+                    imageUrl: post.imageUrl!,
+                    placeholder: (context, url) =>
+                        Center(child: CircularProgressIndicator()),
+                    errorWidget: (context, url, error) => Icon(Icons.error),
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              ],
+              SizedBox(height: 8),
+              Row(
+                children: [
+                  Icon(Icons.arrow_upward),
+                  SizedBox(width: 4),
+                  Text(post.upvotes.toString()),
+                  SizedBox(width: 16),
+                  Icon(Icons.comment),
+                  SizedBox(width: 4),
+                  Text('${post.comments} comments'),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/injection_container.dart
+++ b/lib/injection_container.dart
@@ -4,6 +4,11 @@ import 'package:academia/database/database.dart';
 import 'package:academia/features/auth/auth.dart';
 import 'package:academia/features/auth/data/data.dart';
 import 'package:academia/features/auth/data/datasources/profile_local_datasource.dart';
+import 'package:academia/features/chirp/data/datasources/chirp_remote_data_source.dart';
+import 'package:academia/features/chirp/data/repositories/chirp_repository_impl.dart';
+import 'package:academia/features/chirp/domain/repositories/chirp_repository.dart';
+import 'package:academia/features/chirp/domain/usecases/get_feed_posts.dart';
+import 'package:academia/features/chirp/presentation/bloc/feed/feed_bloc.dart';
 import 'package:get_it/get_it.dart';
 
 final sl = GetIt.instance;
@@ -36,4 +41,10 @@ Future<void> init(FlavorConfig flavor) async {
   sl.registerFactory<GetPreviousAuthState>(
     () => GetPreviousAuthState(sl.get<AuthRepositoryImpl>()),
   );
+
+  // Chirp
+  sl.registerSingleton<ChirpRemoteDataSource>(ChirpRemoteDataSourceImpl());
+  sl.registerSingleton<ChirpRepository>(ChirpRepositoryImpl(sl()));
+  sl.registerSingleton(GetFeedPosts(sl()));
+  sl.registerFactory(() => FeedBloc(sl()));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   flutter_bloc: ^9.1.1
   flutter_native_splash: ^2.4.6
   material_symbols_icons: ^4.2815.1
+  cached_network_image: ^3.4.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR introduces the initial UI implementation of the Chirp feature's feed screen. It sets up the visual layout of the chirp feed, using dummy post data, following the app's clean architecture principles and integrating with the existing GetIt and Bloc setup.

What’s Included:
- Chirp Feed Screen UI built using Flutter widgets.
- Dummy post data used for layout and testing.

Structure adheres to clean architecture:
- Presentation: Feed screen & widgets.
- Dependency registration via get_it.
- Placeholder Bloc wiring for future logic (real data integration not done yet).

 To Do (In next PR):
-  Replace dummy data with live data from backend.
-  Implement BLoC logic (fetch, paginate, refresh).
-  Add like, comment, and chirp interaction capabilities.
