### PR TITLE
Feature/deep links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,11 +17,29 @@
 			<meta-data
         android:name="io.flutter.embedding.android.NormalTheme"
         android:resource="@style/NormalTheme"/>
+      <meta-data
+        android:name="flutter_deeplinking_enabled"
+          android:value="true" />
+
+      <!-- Launcher -->
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"/>
 				<category android:name="android.intent.category.LAUNCHER"/>
 			</intent-filter>
+
+      <!-- Deep linking: For a detailed guide checkout:
+      https://codewithandrea.com/articles/flutter-deep-links/ -->
+      <intent-filter android:autoVerify="true">
+              <action android:name="android.intent.action.VIEW" />
+              <category android:name="android.intent.category.DEFAULT" />
+              <category android:name="android.intent.category.BROWSABLE" />
+              <data android:scheme="https"
+                  android:host="academia.opencrafts.io"/>
+      </intent-filter>
     </activity>
+
+
+    <!-- OAuth callback only -->
     <activity
       android:name="com.linusu.flutter_web_auth_2.CallbackActivity"
       android:exported="true"
@@ -32,18 +50,6 @@
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="academia"/>
       </intent-filter>
-
-      <!-- Deep linking: For a detailed guide checkout:
-        https://codewithandrea.com/articles/flutter-deep-links/ -->
-      <intent-filter android:autoVerify="true">
-              <action android:name="android.intent.action.VIEW" />
-              <category android:name="android.intent.category.DEFAULT" />
-              <category android:name="android.intent.category.BROWSABLE" />
-              <data android:scheme="https"
-                  android:host="academia.opencrafts.io"
-                  android:pathPrefix="/sherehe/create"/>
-      </intent-filter>
-
     </activity>
 		<!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,18 @@
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="academia"/>
       </intent-filter>
+
+      <!-- Deep linking: For a detailed guide checkout:
+        https://codewithandrea.com/articles/flutter-deep-links/ -->
+      <intent-filter android:autoVerify="true">
+              <action android:name="android.intent.action.VIEW" />
+              <category android:name="android.intent.category.DEFAULT" />
+              <category android:name="android.intent.category.BROWSABLE" />
+              <data android:scheme="https"
+                  android:host="academia.opencrafts.io"
+                  android:pathPrefix="/sherehe/create"/>
+      </intent-filter>
+
     </activity>
 		<!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/lib/config/router/app_router.dart
+++ b/lib/config/router/app_router.dart
@@ -15,6 +15,9 @@ class AppRouter {
     navigatorKey: globalNavigatorKey,
     redirect: (context, state) async {
       final authState = BlocProvider.of<AuthBloc>(context).state;
+      if (authState is AuthLoading) {
+        return null;
+      }
       if (authState is AuthUnauthenticated) {
         return AuthRoute().location;
       }

--- a/lib/features/auth/data/datasources/auth_remote_datasource.dart
+++ b/lib/features/auth/data/datasources/auth_remote_datasource.dart
@@ -29,6 +29,7 @@ class AuthRemoteDatasource {
       );
 
       final token = Uri.parse(result).queryParameters['token'];
+      final refreshToken = Uri.parse(result).queryParameters['refresh_token'];
       return right(
         TokenData(
           id: 1,
@@ -36,7 +37,7 @@ class AuthRemoteDatasource {
           expiresAt: DateTime.now().add(Duration(days: 1)),
           createdAt: DateTime.now(),
           accessToken: token!,
-          refreshToken: "",
+          refreshToken: refreshToken!,
           updatedAt: DateTime.now(),
         ),
       );

--- a/lib/main_production.dart
+++ b/lib/main_production.dart
@@ -14,7 +14,7 @@ void main(args) async {
     FlavorConfig(
       flavor: Flavor.production,
       appName: "Academia",
-      apiBaseUrl: "https://qaverisafe.opencrafts.io",
+      apiBaseUrl: "https://api.opencrafts.io",
     ),
   );
 


### PR DESCRIPTION
## fix(android): route normal https deep links to MainActivity instead of CallbackActivity

Previously, both the OAuth redirect (`academia://callback`) and the app’s
https deep links (`https://academia.opencrafts.io/...`) were handled by
`com.linusu.flutter_web_auth_2.CallbackActivity`.  

Because `CallbackActivity` finishes immediately after handling an OAuth
redirect, this caused any direct https deep link launch to result in a
"flash and disappear" behavior with no Flutter UI shown.

### Changes
- Moved `https://academia.opencrafts.io` intent filter to `MainActivity`.
- Kept `academia://callback` intent filter on `CallbackActivity` for OAuth.
- Ensured `MainActivity` has `flutter_deeplinking_enabled` for Flutter routing.

This restores the expected behavior:
- OAuth callbacks are handled invisibly and return tokens to the app.
- Normal https deep links open the Flutter app directly in `MainActivity`.
