### PR TITLE
fix: exception being thrown while marshaling datetime for daily logins

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -35,7 +35,7 @@ class _AcademiaState extends State<Academia> {
     SharedPreferences.getInstance().then((prefs) {
       prefs.setString(
         "user_activity",
-        jsonEncode({"last_app_launch_date": DateTime.now()}),
+        jsonEncode({"last_app_launch_date": DateTime.now().toLocal().toString()}),
       );
     });
 


### PR DESCRIPTION
Initially the application attempted to serialize a dart DateTime object which caused an exception to be thrown on all app sessions.