### PR TITLE
Bumped up database schema version from 29 to 30 and Other Sherehe Changes

### DIFF
--- a/lib/config/router/routes.dart
+++ b/lib/config/router/routes.dart
@@ -278,6 +278,20 @@ class ShereheRoute extends GoRouteData with $ShereheRoute {
   }
 }
 
+@TypedGoRoute<ShereheDetailsWithTokenRoute>(
+  path: "/sherehe/get-event-with-invite/:invite",
+)
+class ShereheDetailsWithTokenRoute extends GoRouteData
+    with $ShereheDetailsWithTokenRoute {
+  final String invite;
+
+  const ShereheDetailsWithTokenRoute({required this.invite});
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return ShereheDetailsPage(invite: invite);
+  }
+}
+
 class CreateEventRoute extends GoRouteData with $CreateEventRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) {
@@ -354,13 +368,26 @@ class ShereheDetailsRoute extends GoRouteData with $ShereheDetailsRoute {
 
 class TicketFlowRoute extends GoRouteData with $TicketFlowRoute {
   final String eventId;
-  final String userId;
 
-  const TicketFlowRoute({required this.eventId, required this.userId});
+  const TicketFlowRoute({required this.eventId});
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return TicketFlowPage(eventId: eventId, userId: userId);
+    return TicketFlowPage(eventId: eventId);
+  }
+}
+
+@TypedGoRoute<TicketFlowWithInviteRoute>(
+  path: "/sherehe/ticket-flow-with-invite/:invite",
+)
+class TicketFlowWithInviteRoute extends GoRouteData with $TicketFlowWithInviteRoute {
+  final String invite;
+
+  const TicketFlowWithInviteRoute({required this.invite});
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return TicketFlowPage(invite: invite);
   }
 }
 

--- a/lib/config/router/routes.g.dart
+++ b/lib/config/router/routes.g.dart
@@ -16,6 +16,8 @@ List<RouteBase> get $appRoutes => [
   $profileRoute,
   $completeProfileRoute,
   $shereheRoute,
+  $shereheDetailsWithTokenRoute,
+  $ticketFlowWithInviteRoute,
   $purchasedTicketsRoute,
   $organizedEventsRoute,
   $ticketReceiptRoute,
@@ -486,17 +488,14 @@ mixin $ShereheDetailsRoute on GoRouteData {
 }
 
 mixin $TicketFlowRoute on GoRouteData {
-  static TicketFlowRoute _fromState(GoRouterState state) => TicketFlowRoute(
-    eventId: state.pathParameters['eventId']!,
-    userId: state.uri.queryParameters['user-id']!,
-  );
+  static TicketFlowRoute _fromState(GoRouterState state) =>
+      TicketFlowRoute(eventId: state.pathParameters['eventId']!);
 
   TicketFlowRoute get _self => this as TicketFlowRoute;
 
   @override
   String get location => GoRouteData.$location(
     '/sherehe/get-event/${Uri.encodeComponent(_self.eventId)}/ticket-flow',
-    queryParams: {'user-id': _self.userId},
   );
 
   @override
@@ -720,6 +719,67 @@ mixin $EditAddedTicketRoute on GoRouteData {
   @override
   String get location =>
       GoRouteData.$location('/sherehe/create/edit-added-ticket');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $shereheDetailsWithTokenRoute => GoRouteData.$route(
+  path: '/sherehe/get-event-with-invite/:invite',
+  factory: $ShereheDetailsWithTokenRoute._fromState,
+);
+
+mixin $ShereheDetailsWithTokenRoute on GoRouteData {
+  static ShereheDetailsWithTokenRoute _fromState(GoRouterState state) =>
+      ShereheDetailsWithTokenRoute(invite: state.pathParameters['invite']!);
+
+  ShereheDetailsWithTokenRoute get _self =>
+      this as ShereheDetailsWithTokenRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/sherehe/get-event-with-invite/${Uri.encodeComponent(_self.invite)}',
+  );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $ticketFlowWithInviteRoute => GoRouteData.$route(
+  path: '/sherehe/ticket-flow-with-invite/:invite',
+  factory: $TicketFlowWithInviteRoute._fromState,
+);
+
+mixin $TicketFlowWithInviteRoute on GoRouteData {
+  static TicketFlowWithInviteRoute _fromState(GoRouterState state) =>
+      TicketFlowWithInviteRoute(invite: state.pathParameters['invite']!);
+
+  TicketFlowWithInviteRoute get _self => this as TicketFlowWithInviteRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/sherehe/ticket-flow-with-invite/${Uri.encodeComponent(_self.invite)}',
+  );
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -117,7 +117,7 @@ class AppDataBase extends _$AppDataBase {
   AppDataBase([QueryExecutor? executor]) : super(executor ?? _openConnection());
 
   @override
-  int get schemaVersion => 29;
+  int get schemaVersion => 30;
 
   @override
   MigrationStrategy get migration {
@@ -173,6 +173,9 @@ class AppDataBase extends _$AppDataBase {
               break;
             case 28:
               await migrate28To29(m);
+              break;
+            case 29:
+              await migrate29To30(m);
               break;
           }
         }

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -5288,9 +5288,9 @@ class $TicketTableTable extends TicketTable
   late final GeneratedColumn<int> ticketFor = GeneratedColumn<int>(
     'ticket_for',
     aliasedName,
-    false,
+    true,
     type: DriftSqlType.int,
-    requiredDuringInsert: true,
+    requiredDuringInsert: false,
   );
   @override
   late final GeneratedColumnWithTypeConverter<List<dynamic>?, String>
@@ -5375,8 +5375,6 @@ class $TicketTableTable extends TicketTable
         _ticketForMeta,
         ticketFor.isAcceptableOrUnknown(data['ticket_for']!, _ticketForMeta),
       );
-    } else if (isInserting) {
-      context.missing(_ticketForMeta);
     }
     if (data.containsKey('scope')) {
       context.handle(
@@ -5416,7 +5414,7 @@ class $TicketTableTable extends TicketTable
       ticketFor: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}ticket_for'],
-      )!,
+      ),
       institutions: $TicketTableTable.$converterinstitutionsn.fromSql(
         attachedDatabase.typeMapping.read(
           DriftSqlType.string,
@@ -5447,7 +5445,7 @@ class TicketData extends DataClass implements Insertable<TicketData> {
   final String ticketName;
   final int ticketPrice;
   final int? ticketQuantity;
-  final int ticketFor;
+  final int? ticketFor;
   final List<dynamic>? institutions;
   final String? scope;
   const TicketData({
@@ -5456,7 +5454,7 @@ class TicketData extends DataClass implements Insertable<TicketData> {
     required this.ticketName,
     required this.ticketPrice,
     this.ticketQuantity,
-    required this.ticketFor,
+    this.ticketFor,
     this.institutions,
     this.scope,
   });
@@ -5474,7 +5472,9 @@ class TicketData extends DataClass implements Insertable<TicketData> {
     if (!nullToAbsent || ticketQuantity != null) {
       map['ticket_quantity'] = Variable<int>(ticketQuantity);
     }
-    map['ticket_for'] = Variable<int>(ticketFor);
+    if (!nullToAbsent || ticketFor != null) {
+      map['ticket_for'] = Variable<int>(ticketFor);
+    }
     if (!nullToAbsent || institutions != null) {
       map['institutions'] = Variable<String>(
         $TicketTableTable.$converterinstitutionsn.toSql(institutions),
@@ -5497,7 +5497,9 @@ class TicketData extends DataClass implements Insertable<TicketData> {
       ticketQuantity: ticketQuantity == null && nullToAbsent
           ? const Value.absent()
           : Value(ticketQuantity),
-      ticketFor: Value(ticketFor),
+      ticketFor: ticketFor == null && nullToAbsent
+          ? const Value.absent()
+          : Value(ticketFor),
       institutions: institutions == null && nullToAbsent
           ? const Value.absent()
           : Value(institutions),
@@ -5518,7 +5520,7 @@ class TicketData extends DataClass implements Insertable<TicketData> {
       ticketName: serializer.fromJson<String>(json['ticket_name']),
       ticketPrice: serializer.fromJson<int>(json['ticket_price']),
       ticketQuantity: serializer.fromJson<int?>(json['ticket_quantity']),
-      ticketFor: serializer.fromJson<int>(json['ticket_for']),
+      ticketFor: serializer.fromJson<int?>(json['ticket_for']),
       institutions: serializer.fromJson<List<dynamic>?>(json['institutions']),
       scope: serializer.fromJson<String?>(json['scope']),
     );
@@ -5532,7 +5534,7 @@ class TicketData extends DataClass implements Insertable<TicketData> {
       'ticket_name': serializer.toJson<String>(ticketName),
       'ticket_price': serializer.toJson<int>(ticketPrice),
       'ticket_quantity': serializer.toJson<int?>(ticketQuantity),
-      'ticket_for': serializer.toJson<int>(ticketFor),
+      'ticket_for': serializer.toJson<int?>(ticketFor),
       'institutions': serializer.toJson<List<dynamic>?>(institutions),
       'scope': serializer.toJson<String?>(scope),
     };
@@ -5544,7 +5546,7 @@ class TicketData extends DataClass implements Insertable<TicketData> {
     String? ticketName,
     int? ticketPrice,
     Value<int?> ticketQuantity = const Value.absent(),
-    int? ticketFor,
+    Value<int?> ticketFor = const Value.absent(),
     Value<List<dynamic>?> institutions = const Value.absent(),
     Value<String?> scope = const Value.absent(),
   }) => TicketData(
@@ -5555,7 +5557,7 @@ class TicketData extends DataClass implements Insertable<TicketData> {
     ticketQuantity: ticketQuantity.present
         ? ticketQuantity.value
         : this.ticketQuantity,
-    ticketFor: ticketFor ?? this.ticketFor,
+    ticketFor: ticketFor.present ? ticketFor.value : this.ticketFor,
     institutions: institutions.present ? institutions.value : this.institutions,
     scope: scope.present ? scope.value : this.scope,
   );
@@ -5626,7 +5628,7 @@ class TicketTableCompanion extends UpdateCompanion<TicketData> {
   final Value<String> ticketName;
   final Value<int> ticketPrice;
   final Value<int?> ticketQuantity;
-  final Value<int> ticketFor;
+  final Value<int?> ticketFor;
   final Value<List<dynamic>?> institutions;
   final Value<String?> scope;
   final Value<int> rowid;
@@ -5647,13 +5649,12 @@ class TicketTableCompanion extends UpdateCompanion<TicketData> {
     required String ticketName,
     required int ticketPrice,
     this.ticketQuantity = const Value.absent(),
-    required int ticketFor,
+    this.ticketFor = const Value.absent(),
     this.institutions = const Value.absent(),
     this.scope = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : ticketName = Value(ticketName),
-       ticketPrice = Value(ticketPrice),
-       ticketFor = Value(ticketFor);
+       ticketPrice = Value(ticketPrice);
   static Insertable<TicketData> custom({
     Expression<String>? id,
     Expression<String>? eventId,
@@ -5684,7 +5685,7 @@ class TicketTableCompanion extends UpdateCompanion<TicketData> {
     Value<String>? ticketName,
     Value<int>? ticketPrice,
     Value<int?>? ticketQuantity,
-    Value<int>? ticketFor,
+    Value<int?>? ticketFor,
     Value<List<dynamic>?>? institutions,
     Value<String?>? scope,
     Value<int>? rowid,
@@ -25617,7 +25618,7 @@ typedef $$TicketTableTableCreateCompanionBuilder =
       required String ticketName,
       required int ticketPrice,
       Value<int?> ticketQuantity,
-      required int ticketFor,
+      Value<int?> ticketFor,
       Value<List<dynamic>?> institutions,
       Value<String?> scope,
       Value<int> rowid,
@@ -25629,7 +25630,7 @@ typedef $$TicketTableTableUpdateCompanionBuilder =
       Value<String> ticketName,
       Value<int> ticketPrice,
       Value<int?> ticketQuantity,
-      Value<int> ticketFor,
+      Value<int?> ticketFor,
       Value<List<dynamic>?> institutions,
       Value<String?> scope,
       Value<int> rowid,
@@ -25815,7 +25816,7 @@ class $$TicketTableTableTableManager
                 Value<String> ticketName = const Value.absent(),
                 Value<int> ticketPrice = const Value.absent(),
                 Value<int?> ticketQuantity = const Value.absent(),
-                Value<int> ticketFor = const Value.absent(),
+                Value<int?> ticketFor = const Value.absent(),
                 Value<List<dynamic>?> institutions = const Value.absent(),
                 Value<String?> scope = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -25837,7 +25838,7 @@ class $$TicketTableTableTableManager
                 required String ticketName,
                 required int ticketPrice,
                 Value<int?> ticketQuantity = const Value.absent(),
-                required int ticketFor,
+                Value<int?> ticketFor = const Value.absent(),
                 Value<List<dynamic>?> institutions = const Value.absent(),
                 Value<String?> scope = const Value.absent(),
                 Value<int> rowid = const Value.absent(),

--- a/lib/database/migrations.dart
+++ b/lib/database/migrations.dart
@@ -94,4 +94,9 @@ extension AppDatabaseExtension on AppDataBase {
     await m.database.customStatement("DROP TABLE IF EXISTS 'event_table';");
     await m.createTable(eventTable);
   }
+
+  Future<void> migrate29To30(Migrator m) async {
+    await m.database.customStatement("DROP TABLE IF EXISTS 'ticket_table';");
+    await m.createTable(ticketTable);
+  }
 }

--- a/lib/database/migrations/drift_schema_v30.json
+++ b/lib/database/migrations/drift_schema_v30.json
@@ -1,0 +1,4799 @@
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.3.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": 0,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "user_profile",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "username",
+            "getter_name": "username",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "email",
+            "getter_name": "email",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "terms_accepted",
+            "getter_name": "termsAccepted",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"terms_accepted\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"terms_accepted\" IN (0, 1))"
+            },
+            "default_dart": "Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "onboarded",
+            "getter_name": "onboarded",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"onboarded\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"onboarded\" IN (0, 1))"
+            },
+            "default_dart": "Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "national_i_d",
+            "getter_name": "nationalID",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "avatar_url",
+            "getter_name": "avatarUrl",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "bio",
+            "getter_name": "bio",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "phone",
+            "getter_name": "phone",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "vibe_points",
+            "getter_name": "vibePoints",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "deleted_at",
+            "getter_name": "deletedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "attachment_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "PRIMARY KEY AUTOINCREMENT",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "PRIMARY KEY AUTOINCREMENT"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "auto-increment"
+            ]
+          },
+          {
+            "name": "attachment_type",
+            "getter_name": "attachmentType",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "allowed-lengths": {
+                  "min": null,
+                  "max": 20
+                }
+              }
+            ]
+          },
+          {
+            "name": "file",
+            "getter_name": "file",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "size",
+            "getter_name": "size",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "post_id",
+            "getter_name": "postId",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 2,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "post_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "PRIMARY KEY AUTOINCREMENT",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "PRIMARY KEY AUTOINCREMENT"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "auto-increment"
+            ]
+          },
+          {
+            "name": "community",
+            "getter_name": "community",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonConverter()",
+              "dart_type_name": "Map<String, dynamic>"
+            }
+          },
+          {
+            "name": "author_id",
+            "getter_name": "authorId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "title",
+            "getter_name": "title",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "content",
+            "getter_name": "content",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "upvotes",
+            "getter_name": "upvotes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "downvotes",
+            "getter_name": "downvotes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "attachments",
+            "getter_name": "attachments",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          },
+          {
+            "name": "views_count",
+            "getter_name": "viewsCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "comment_count",
+            "getter_name": "commentCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "comments",
+            "getter_name": "comments",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "cached_at",
+            "getter_name": "cachedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 3,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "comment_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "post",
+            "getter_name": "post",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "author_id",
+            "getter_name": "authorId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "content",
+            "getter_name": "content",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "upvotes",
+            "getter_name": "upvotes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "downvotes",
+            "getter_name": "downvotes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "replies",
+            "getter_name": "replies",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          },
+          {
+            "name": "parent",
+            "getter_name": "parent",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 4,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "todo",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "external_i_d",
+            "getter_name": "externalID",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "completed",
+            "getter_name": "completed",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "deleted",
+            "getter_name": "deleted",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"deleted\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"deleted\" IN (0, 1))"
+            },
+            "default_dart": "Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "due",
+            "getter_name": "due",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "etag",
+            "getter_name": "etag",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "hidden",
+            "getter_name": "hidden",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"hidden\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"hidden\" IN (0, 1))"
+            },
+            "default_dart": "Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "notes",
+            "getter_name": "notes",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "owner",
+            "getter_name": "owner",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "parent",
+            "getter_name": "parent",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "position",
+            "getter_name": "position",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "self_link",
+            "getter_name": "selfLink",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "status",
+            "getter_name": "status",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "title",
+            "getter_name": "title",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated",
+            "getter_name": "updated",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "web_view_link",
+            "getter_name": "webViewLink",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "event_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_name",
+            "getter_name": "eventName",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_description",
+            "getter_name": "eventDescription",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_location",
+            "getter_name": "eventLocation",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "start_date",
+            "getter_name": "startDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "end_date",
+            "getter_name": "endDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "attendee_count",
+            "getter_name": "attendeeCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "organizer_id",
+            "getter_name": "organizerId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_card_image",
+            "getter_name": "eventCardImage",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_poster_image",
+            "getter_name": "eventPosterImage",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_banner_image",
+            "getter_name": "eventBannerImage",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_url",
+            "getter_name": "eventUrl",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_genre",
+            "getter_name": "eventGenre",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "deleted_at",
+            "getter_name": "deletedAt",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "scope",
+            "getter_name": "scope",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "institutions",
+            "getter_name": "institutions",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          },
+          {
+            "name": "payment_info",
+            "getter_name": "paymentInfo",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonConverter()",
+              "dart_type_name": "Map<String, dynamic>"
+            }
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 6,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "attendee_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "user_id",
+            "getter_name": "userId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_id",
+            "getter_name": "eventId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ticket_id",
+            "getter_name": "ticketId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ticket_quantity",
+            "getter_name": "ticketQuantity",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "user",
+            "getter_name": "user",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonConverter()",
+              "dart_type_name": "Map<String, dynamic>"
+            }
+          },
+          {
+            "name": "ticket",
+            "getter_name": "ticket",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonConverter()",
+              "dart_type_name": "Map<String, dynamic>"
+            }
+          },
+          {
+            "name": "event",
+            "getter_name": "event",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonConverter()",
+              "dart_type_name": "Map<String, dynamic>"
+            }
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 7,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "ticket_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_id",
+            "getter_name": "eventId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ticket_name",
+            "getter_name": "ticketName",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ticket_price",
+            "getter_name": "ticketPrice",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ticket_quantity",
+            "getter_name": "ticketQuantity",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ticket_for",
+            "getter_name": "ticketFor",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "institutions",
+            "getter_name": "institutions",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          },
+          {
+            "name": "scope",
+            "getter_name": "scope",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 8,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "payment_info_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "payment_type",
+            "getter_name": "paymentType",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "paybill_number",
+            "getter_name": "paybillNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "paybill_account_number",
+            "getter_name": "paybillAccountNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "till_number",
+            "getter_name": "tillNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "phone_number",
+            "getter_name": "phoneNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "deleted_at",
+            "getter_name": "deletedAt",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 9,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "sherehe_user_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "username",
+            "getter_name": "username",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "email",
+            "getter_name": "email",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "phone",
+            "getter_name": "phone",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 10,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "dashboard_stats_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "attendees",
+            "getter_name": "attendees",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "scanners",
+            "getter_name": "scanners",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 11,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "ticket_stats_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "ticket_id",
+            "getter_name": "ticketId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ticket_name",
+            "getter_name": "ticketName",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ticket_price",
+            "getter_name": "ticketPrice",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tickets_sold",
+            "getter_name": "ticketsSold",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tickets_remaining",
+            "getter_name": "ticketsRemaining",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 12,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "scanner_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_id",
+            "getter_name": "eventId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "user_id",
+            "getter_name": "userId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "role",
+            "getter_name": "role",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "granted_by",
+            "getter_name": "grantedBy",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "user",
+            "getter_name": "user",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonConverter()",
+              "dart_type_name": "Map<String, dynamic>"
+            }
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "deleted_at",
+            "getter_name": "deletedAt",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 13,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "group_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "description",
+            "getter_name": "description",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "creator_id",
+            "getter_name": "creatorId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "creator_name",
+            "getter_name": "creatorName",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "admins",
+            "getter_name": "admins",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "admin_names",
+            "getter_name": "adminNames",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "moderators",
+            "getter_name": "moderators",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "moderator_names",
+            "getter_name": "moderatorNames",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "members",
+            "getter_name": "members",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "member_names",
+            "getter_name": "memberNames",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banned_users",
+            "getter_name": "bannedUsers",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banned_user_names",
+            "getter_name": "bannedUserNames",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "is_private",
+            "getter_name": "isPrivate",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"is_private\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"is_private\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "rules",
+            "getter_name": "rules",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "logo",
+            "getter_name": "logo",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banner",
+            "getter_name": "banner",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "logo_url",
+            "getter_name": "logoUrl",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banner_url",
+            "getter_name": "bannerUrl",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "user_role",
+            "getter_name": "userRole",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "can_post",
+            "getter_name": "canPost",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"can_post\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"can_post\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "can_moderate",
+            "getter_name": "canModerate",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"can_moderate\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"can_moderate\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "can_admin",
+            "getter_name": "canAdmin",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"can_admin\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"can_admin\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 14,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "block_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "block_type",
+            "getter_name": "blockType",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "allowed-lengths": {
+                  "min": 1,
+                  "max": 20
+                }
+              }
+            ]
+          },
+          {
+            "name": "blocked_user",
+            "getter_name": "blockedUser",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "blocked_community",
+            "getter_name": "blockedCommunity",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "blocked_name",
+            "getter_name": "blockedName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "blocked_image",
+            "getter_name": "blockedImage",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "cached_at",
+            "getter_name": "cachedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "currentDateAndTime",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 15,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "report_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "report_type",
+            "getter_name": "reportType",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "allowed-lengths": {
+                  "min": 1,
+                  "max": 20
+                }
+              }
+            ]
+          },
+          {
+            "name": "reported_user",
+            "getter_name": "reportedUser",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "reported_post",
+            "getter_name": "reportedPost",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "reported_comment",
+            "getter_name": "reportedComment",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "reported_community",
+            "getter_name": "reportedCommunity",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "reason",
+            "getter_name": "reason",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "status",
+            "getter_name": "status",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const Constant('pending')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "cached_at",
+            "getter_name": "cachedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "currentDateAndTime",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 16,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "agenda_event",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "all_day",
+            "getter_name": "allDay",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"all_day\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"all_day\" IN (0, 1))"
+            },
+            "default_dart": "const Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "summary",
+            "getter_name": "summary",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "description",
+            "getter_name": "description",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "location",
+            "getter_name": "location",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "html_link",
+            "getter_name": "htmlLink",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "calendar_id",
+            "getter_name": "calendarId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "owner_id",
+            "getter_name": "ownerId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "timezone",
+            "getter_name": "timezone",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "status",
+            "getter_name": "status",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "transparency",
+            "getter_name": "transparency",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "etag",
+            "getter_name": "etag",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created",
+            "getter_name": "created",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated",
+            "getter_name": "updated",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "start_time",
+            "getter_name": "startTime",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "end_time",
+            "getter_name": "endTime",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "attendees",
+            "getter_name": "attendees",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "const JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          },
+          {
+            "name": "recurrence",
+            "getter_name": "recurrence",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "const JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          },
+          {
+            "name": "reminders",
+            "getter_name": "reminders",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "const JsonConverter()",
+              "dart_type_name": "Map<String, dynamic>"
+            }
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 17,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "notification_table",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "title",
+            "getter_name": "title",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "body",
+            "getter_name": "body",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "image_url",
+            "getter_name": "imageUrl",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "data",
+            "getter_name": "data",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "const JsonConverter()",
+              "dart_type_name": "Map<String, dynamic>"
+            }
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "is_read",
+            "getter_name": "isRead",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"is_read\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"is_read\" IN (0, 1))"
+            },
+            "default_dart": "const Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "category",
+            "getter_name": "category",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "action_url",
+            "getter_name": "actionUrl",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 18,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "institution",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "institution_id",
+            "getter_name": "institutionId",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "web_pages",
+            "getter_name": "webPages",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "const JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          },
+          {
+            "name": "domains",
+            "getter_name": "domains",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "const JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          },
+          {
+            "name": "alpha_two_code",
+            "getter_name": "alphaTwoCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "country",
+            "getter_name": "country",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "state_province",
+            "getter_name": "stateProvince",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "institution_id"
+        ]
+      }
+    },
+    {
+      "id": 19,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "institution_scrapping_command",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "institution",
+            "getter_name": "institution",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "command_i_d",
+            "getter_name": "commandID",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "url",
+            "getter_name": "url",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "description",
+            "getter_name": "description",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "requires_interaction",
+            "getter_name": "requiresInteraction",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"requires_interaction\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"requires_interaction\" IN (0, 1))"
+            },
+            "default_dart": "Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "instructions",
+            "getter_name": "instructions",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "command_i_d"
+        ]
+      }
+    },
+    {
+      "id": 20,
+      "references": [
+        18,
+        19
+      ],
+      "type": "table",
+      "data": {
+        "name": "institution_key",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "institution_id",
+            "getter_name": "institutionID",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES institution (institution_id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES institution (institution_id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "institution",
+                    "column": "institution_id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "command_i_d",
+            "getter_name": "commandID",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES institution_scrapping_command (command_i_d)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES institution_scrapping_command (command_i_d)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "institution_scrapping_command",
+                    "column": "command_i_d"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "key_sets",
+            "getter_name": "keySets",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonConverter()",
+              "dart_type_name": "Map<String, dynamic>"
+            }
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "institution_id",
+          "command_i_d"
+        ]
+      }
+    },
+    {
+      "id": 21,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "institution_profile",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "user_id",
+            "getter_name": "userID",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "institution_id",
+            "getter_name": "institutionID",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "student_id",
+            "getter_name": "studentID",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "student_name",
+            "getter_name": "studentName",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(\"\")",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "gender",
+            "getter_name": "gender",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(Gender.unknown.name)",
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "const EnumNameConverter<Gender>(Gender.values)",
+              "dart_type_name": "Gender"
+            }
+          },
+          {
+            "name": "status",
+            "getter_name": "status",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(AcademicStatus.unknown.name)",
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "const EnumNameConverter<AcademicStatus>(AcademicStatus.values)",
+              "dart_type_name": "AcademicStatus"
+            }
+          },
+          {
+            "name": "email",
+            "getter_name": "email",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "profile_picture",
+            "getter_name": "profilePicture",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "national_id",
+            "getter_name": "nationalID",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "nationality",
+            "getter_name": "nationality",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "program",
+            "getter_name": "program",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "major",
+            "getter_name": "major",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "year",
+            "getter_name": "year",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "gpa",
+            "getter_name": "gpa",
+            "moor_type": "double",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "disability_status",
+            "getter_name": "disabilityStatus",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "school",
+            "getter_name": "school",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "phone",
+            "getter_name": "phone",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "address",
+            "getter_name": "address",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "enrollment_date",
+            "getter_name": "enrollmentDate",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "expected_graduation",
+            "getter_name": "expectedGraduation",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "raw_data",
+            "getter_name": "rawData",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "const JsonConverter()",
+              "dart_type_name": "Map<String, dynamic>"
+            }
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "currentDateAndTime",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "currentDateAndTime",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "institution_id",
+          "user_id"
+        ]
+      }
+    },
+    {
+      "id": 22,
+      "references": [
+        18
+      ],
+      "type": "table",
+      "data": {
+        "name": "institution_fee_transaction",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "institution",
+            "getter_name": "institution",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES institution (institution_id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES institution (institution_id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "institution",
+                    "column": "institution_id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "reference_number",
+            "getter_name": "referenceNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "allowed-lengths": {
+                  "min": 1,
+                  "max": 255
+                }
+              }
+            ]
+          },
+          {
+            "name": "running_balance",
+            "getter_name": "runningBalance",
+            "moor_type": "double",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "debit",
+            "getter_name": "debit",
+            "moor_type": "double",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(0.0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "credit",
+            "getter_name": "credit",
+            "moor_type": "double",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(0.0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "posting_date",
+            "getter_name": "postingDate",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "description",
+            "getter_name": "description",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "title",
+            "getter_name": "title",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "currency",
+            "getter_name": "currency",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(\"KES\")",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "institution",
+          "reference_number"
+        ]
+      }
+    },
+    {
+      "id": 23,
+      "references": [
+        18
+      ],
+      "type": "table",
+      "data": {
+        "name": "semester",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "PRIMARY KEY AUTOINCREMENT",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "PRIMARY KEY AUTOINCREMENT"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "auto-increment"
+            ]
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "description",
+            "getter_name": "description",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "institution_id",
+            "getter_name": "institutionId",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES institution (institution_id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES institution (institution_id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "institution",
+                    "column": "institution_id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "start_date",
+            "getter_name": "startDate",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "currentDateAndTime",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "end_date",
+            "getter_name": "endDate",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "currentDateAndTime",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 24,
+      "references": [
+        18,
+        23
+      ],
+      "type": "table",
+      "data": {
+        "name": "course",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": "generateUuid",
+            "dsl_features": []
+          },
+          {
+            "name": "server_id",
+            "getter_name": "serverId",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "institution",
+            "getter_name": "institution",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES institution (institution_id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES institution (institution_id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "institution",
+                    "column": "institution_id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "semester",
+            "getter_name": "semester",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES semester (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES semester (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "semester",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "course_code",
+            "getter_name": "courseCode",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "course_name",
+            "getter_name": "courseName",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "instructor",
+            "getter_name": "instructor",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "color",
+            "getter_name": "color",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(0x1E1E2EFF)",
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "ColorConverter()",
+              "dart_type_name": "Color"
+            }
+          },
+          {
+            "name": "is_synced",
+            "getter_name": "isSynced",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"is_synced\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"is_synced\" IN (0, 1))"
+            },
+            "default_dart": "Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "is_deleted",
+            "getter_name": "isDeleted",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"is_deleted\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"is_deleted\" IN (0, 1))"
+            },
+            "default_dart": "const Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "currentDateAndTime",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "currentDateAndTime",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 25,
+      "references": [
+        18
+      ],
+      "type": "table",
+      "data": {
+        "name": "timetable",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": "generateUuid",
+            "dsl_features": []
+          },
+          {
+            "name": "server_id",
+            "getter_name": "serverId",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "user_id",
+            "getter_name": "userId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "institution",
+            "getter_name": "institution",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES institution (institution_id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES institution (institution_id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "institution",
+                    "column": "institution_id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "is_synced",
+            "getter_name": "isSynced",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"is_synced\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"is_synced\" IN (0, 1))"
+            },
+            "default_dart": "Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "is_deleted",
+            "getter_name": "isDeleted",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"is_deleted\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"is_deleted\" IN (0, 1))"
+            },
+            "default_dart": "const Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "currentDateAndTime",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "currentDateAndTime",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 26,
+      "references": [
+        24,
+        25
+      ],
+      "type": "table",
+      "data": {
+        "name": "timetable_entry",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": "generateUuid",
+            "dsl_features": []
+          },
+          {
+            "name": "server_id",
+            "getter_name": "serverId",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "user_id",
+            "getter_name": "userId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "institution_id",
+            "getter_name": "institutionId",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "course_id",
+            "getter_name": "courseId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES course (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES course (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "course",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "timetable_id",
+            "getter_name": "timetableId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES timetable (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES timetable (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "timetable",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "rrule",
+            "getter_name": "rrule",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "start_date",
+            "getter_name": "startDate",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "duration_minutes",
+            "getter_name": "durationMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "location",
+            "getter_name": "location",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "room",
+            "getter_name": "room",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "building",
+            "getter_name": "building",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "is_synced",
+            "getter_name": "isSynced",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"is_synced\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"is_synced\" IN (0, 1))"
+            },
+            "default_dart": "const Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "is_deleted",
+            "getter_name": "isDeleted",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"is_deleted\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"is_deleted\" IN (0, 1))"
+            },
+            "default_dart": "const Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "last_updated",
+            "getter_name": "lastUpdated",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "currentDateAndTime",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 27,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "exam_timetable",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "course_code",
+            "getter_name": "courseCode",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "day",
+            "getter_name": "day",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "start_time",
+            "getter_name": "startTime",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "end_time",
+            "getter_name": "endTime",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "venue",
+            "getter_name": "venue",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "hrs",
+            "getter_name": "hrs",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "campus",
+            "getter_name": "campus",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "coordinator",
+            "getter_name": "coordinator",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "invigilator",
+            "getter_name": "invigilator",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "datetime_str",
+            "getter_name": "datetimeStr",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "course_code"
+        ]
+      }
+    },
+    {
+      "id": 28,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "chirp_user",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "user_i_d",
+            "getter_name": "userID",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "email",
+            "getter_name": "email",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "phone",
+            "getter_name": "phone",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "username",
+            "getter_name": "username",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "vibe_points",
+            "getter_name": "vibePoints",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "avatar_url",
+            "getter_name": "avatarUrl",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "cached_at",
+            "getter_name": "cachedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "user_i_d"
+        ]
+      }
+    },
+    {
+      "id": 29,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "community",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "PRIMARY KEY AUTOINCREMENT",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "PRIMARY KEY AUTOINCREMENT"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "auto-increment"
+            ]
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "description",
+            "getter_name": "description",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "nsfw",
+            "getter_name": "nsfw",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"nsfw\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"nsfw\" IN (0, 1))"
+            },
+            "default_dart": "Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "private",
+            "getter_name": "private",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"private\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"private\" IN (0, 1))"
+            },
+            "default_dart": "Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "verified",
+            "getter_name": "verified",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"verified\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"verified\" IN (0, 1))"
+            },
+            "default_dart": "Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "visibility",
+            "getter_name": "visibility",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "member_count",
+            "getter_name": "memberCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "moderator_count",
+            "getter_name": "moderatorCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banned_users_count",
+            "getter_name": "bannedUsersCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "monthly_visitor_count",
+            "getter_name": "monthlyVisitorCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "weekly_visitor_count",
+            "getter_name": "weeklyVisitorCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banner",
+            "getter_name": "banner",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banner_height",
+            "getter_name": "bannerHeight",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banner_width",
+            "getter_name": "bannerWidth",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banner_url",
+            "getter_name": "bannerUrl",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "profile_picture",
+            "getter_name": "profilePicture",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "profile_picture_height",
+            "getter_name": "profilePictureHeight",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "profile_picture_width",
+            "getter_name": "profilePictureWidth",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "profile_picture_url",
+            "getter_name": "profilePictureUrl",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "creator_id",
+            "getter_name": "creatorId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "guidelines",
+            "getter_name": "guidelines",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [],
+            "type_converter": {
+              "dart_expr": "JsonListConverter()",
+              "dart_type_name": "List<dynamic>"
+            }
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "cached_at",
+            "getter_name": "cachedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 30,
+      "references": [
+        28
+      ],
+      "type": "table",
+      "data": {
+        "name": "chirp_community_membership",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "community_i_d",
+            "getter_name": "communityID",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "user_i_d",
+            "getter_name": "userID",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES chirp_user (user_i_d)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES chirp_user (user_i_d)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "chirp_user",
+                    "column": "user_i_d"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "role",
+            "getter_name": "role",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banned",
+            "getter_name": "banned",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"banned\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"banned\" IN (0, 1))"
+            },
+            "default_dart": "Constant(false)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banned_by_i_d",
+            "getter_name": "bannedByID",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banned_reason",
+            "getter_name": "bannedReason",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "banned_at",
+            "getter_name": "bannedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "joined_at",
+            "getter_name": "joinedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "cached_at",
+            "getter_name": "cachedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 31,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "leaderboard_rank",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "avatar_url",
+            "getter_name": "avatarUrl",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "email",
+            "getter_name": "email",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "username",
+            "getter_name": "username",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "vibe_points",
+            "getter_name": "vibePoints",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "vibe_rank",
+            "getter_name": "vibeRank",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "cached_at",
+            "getter_name": "cachedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 32,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "streak_activity",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "description",
+            "getter_name": "description",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "category",
+            "getter_name": "category",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "points_awarded",
+            "getter_name": "pointsAwarded",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "max_daily_completions",
+            "getter_name": "maxDailyCompletions",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "streak_eligible",
+            "getter_name": "streakEligible",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"streak_eligible\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"streak_eligible\" IN (0, 1))"
+            },
+            "default_dart": "Constant(true)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "is_active",
+            "getter_name": "isActive",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"is_active\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"is_active\" IN (0, 1))"
+            },
+            "default_dart": "Constant(true)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "cached_at",
+            "getter_name": "cachedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 33,
+      "references": [
+        32
+      ],
+      "type": "table",
+      "data": {
+        "name": "streak_milestone",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "activity_i_d",
+            "getter_name": "activityID",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES streak_activity (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES streak_activity (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "streak_activity",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "days_required",
+            "getter_name": "daysRequired",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "bonus_points",
+            "getter_name": "bonusPoints",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "Constant(0)",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "title",
+            "getter_name": "title",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "description",
+            "getter_name": "description",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "is_active",
+            "getter_name": "isActive",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"is_active\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"is_active\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "cached_at",
+            "getter_name": "cachedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": "Constant(DateTime.now())",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    }
+  ]
+}

--- a/lib/features/sherehe/data/datasources/sherehe_remote_datasource.dart
+++ b/lib/features/sherehe/data/datasources/sherehe_remote_datasource.dart
@@ -416,7 +416,9 @@ class ShereheRemoteDataSource with DioErrorHandler {
     }
   }
 
-  Future<Either<Failure, TicketData>> getTicketByInvite({required String invite}) async {
+  Future<Either<Failure, TicketData>> getTicketByInvite({
+    required String invite,
+  }) async {
     try {
       final response = await dioClient.dio.get(
         "/$servicePrefix/invite/ticket/$invite",
@@ -436,16 +438,10 @@ class ShereheRemoteDataSource with DioErrorHandler {
         );
       }
     } on DioException catch (de) {
-      _logger.e(
-        "DioException when fetching ticket",
-        error: de,
-      );
+      _logger.e("DioException when fetching ticket", error: de);
       return handleDioError(de);
     } catch (e) {
-      _logger.e(
-        "Unknown error when fetching ticket",
-        error: e,
-      );
+      _logger.e("Unknown error when fetching ticket", error: e);
       return left(
         ServerFailure(
           message: "An unexpected error occurred while fetching the ticket",
@@ -471,16 +467,6 @@ class ShereheRemoteDataSource with DioErrorHandler {
       );
 
       if (response.statusCode == 200 || response.statusCode == 201) {
-        // FREE EVENT
-        if (response.data.containsKey('attendee_id')) {
-          return right(
-            FreeTicketSuccess(
-              message: response.data['message'],
-              attendeeId: response.data['attendee_id'],
-            ),
-          );
-        }
-
         // PAID EVENT
         if (response.data.containsKey('trans_id')) {
           return right(
@@ -489,13 +475,19 @@ class ShereheRemoteDataSource with DioErrorHandler {
               transactionId: response.data['trans_id'],
             ),
           );
+        } else {
+          // FREE EVENT
+          if (response.data.containsKey('message')) {
+            return right(FreeTicketSuccess(message: response.data['message']));
+          } else {
+            return left(
+              ServerFailure(
+                message: "Unknown success response format",
+                error: response,
+              ),
+            );
+          }
         }
-        return left(
-          ServerFailure(
-            message: "Unknown success response format",
-            error: response,
-          ),
-        );
       } else {
         return left(
           ServerFailure(

--- a/lib/features/sherehe/data/datasources/sherehe_remote_datasource.dart
+++ b/lib/features/sherehe/data/datasources/sherehe_remote_datasource.dart
@@ -416,7 +416,7 @@ class ShereheRemoteDataSource with DioErrorHandler {
     }
   }
 
-  Future<Either<Failure, TicketData>> getTicketByInvite(String invite) async {
+  Future<Either<Failure, TicketData>> getTicketByInvite({required String invite}) async {
     try {
       final response = await dioClient.dio.get(
         "/$servicePrefix/invite/ticket/$invite",

--- a/lib/features/sherehe/data/models/purchase_ticket_result_model.dart
+++ b/lib/features/sherehe/data/models/purchase_ticket_result_model.dart
@@ -4,12 +4,7 @@ abstract class PurchaseTicketResult {
 }
 
 class FreeTicketSuccess extends PurchaseTicketResult {
-  final String attendeeId;
-
-  const FreeTicketSuccess({
-    required String message,
-    required this.attendeeId,
-  }) : super(message);
+  const FreeTicketSuccess({required String message}) : super(message);
 }
 
 class PaidTicketInitiated extends PurchaseTicketResult {

--- a/lib/features/sherehe/data/models/ticket_model.dart
+++ b/lib/features/sherehe/data/models/ticket_model.dart
@@ -18,7 +18,7 @@ class TicketTable extends Table {
   IntColumn get ticketQuantity => integer().nullable()();
 
   @JsonKey('ticket_for')
-  IntColumn get ticketFor => integer()();
+  IntColumn get ticketFor => integer().nullable()();
 
   @JsonKey('institutions')
   TextColumn get institutions => text().map(JsonListConverter()).nullable()();

--- a/lib/features/sherehe/data/repository/sherehe_repository_impl.dart
+++ b/lib/features/sherehe/data/repository/sherehe_repository_impl.dart
@@ -130,6 +130,17 @@ class ShereheRepositoryImpl implements ShereheRepository {
   }
 
   @override
+  Future<Either<Failure, Event>> getEventByInvite({
+    required String invite,
+  }) async {
+    final result = await remoteDataSource.getEventByInvite(invite: invite);
+    return result.fold(
+      (failure) => left(failure),
+      (eventData) => right(eventData.toEntity()),
+    );
+  }
+
+  @override
   Future<Either<Failure, Attendee>> getAttendeeByID(String id) async {
     final result = await remoteDataSource.getAttendeeByID(id);
     return result.fold(
@@ -146,6 +157,17 @@ class ShereheRepositoryImpl implements ShereheRepository {
     return result.fold(
       (failure) => left(failure),
       (tickets) => right(tickets.map((ticket) => ticket.toEntity()).toList()),
+    );
+  }
+
+  @override
+  Future<Either<Failure, Ticket>> getTicketByInvite({
+    required String invite,
+  }) async {
+    final result = await remoteDataSource.getTicketByInvite(invite: invite);
+    return result.fold(
+      (failure) => left(failure),
+      (ticketData) => right(ticketData.toEntity()),
     );
   }
 

--- a/lib/features/sherehe/domain/domain.dart
+++ b/lib/features/sherehe/domain/domain.dart
@@ -34,3 +34,5 @@ export 'usecases/add_event_scanner_usecase.dart';
 export 'usecases/delete_event_scanner_usecase.dart';
 export 'usecases/get_all_event_scanners_usecase.dart';
 export 'usecases/get_event_scanner_by_user_id_usecase.dart';
+export 'usecases/get_event_by_invite_usecase.dart';
+export 'usecases/get_ticket_by_invite_usecase.dart';

--- a/lib/features/sherehe/domain/entities/ticket.dart
+++ b/lib/features/sherehe/domain/entities/ticket.dart
@@ -6,7 +6,7 @@ class Ticket extends Equatable {
   final String ticketName;
   final int ticketPrice;
   final int? ticketQuantity;
-  final int ticketFor;
+  final int? ticketFor;
   final List<int>? institutionIds;
   final String? scope;
 
@@ -16,7 +16,7 @@ class Ticket extends Equatable {
     required this.ticketName,
     required this.ticketPrice,
     this.ticketQuantity,
-    required this.ticketFor,
+    this.ticketFor,
     this.institutionIds,
     this.scope,
   });

--- a/lib/features/sherehe/domain/repository/sherehe_repository.dart
+++ b/lib/features/sherehe/domain/repository/sherehe_repository.dart
@@ -45,9 +45,13 @@ abstract class ShereheRepository {
     required int limit,
   });
 
+  Future<Either<Failure, Event>> getEventByInvite({required String invite});
+
   Future<Either<Failure, Attendee>> getAttendeeByID(String id);
 
   Future<Either<Failure, List<Ticket>>> getTicketByEventId(String eventId);
+
+  Future<Either<Failure, Ticket>> getTicketByInvite({required String invite});
 
   Future<Either<Failure, PurchaseTicketResult>> purchaseTicket({
     required String ticketId,

--- a/lib/features/sherehe/domain/usecases/get_event_by_invite_usecase.dart
+++ b/lib/features/sherehe/domain/usecases/get_event_by_invite_usecase.dart
@@ -1,0 +1,13 @@
+import 'package:dartz/dartz.dart';
+import '../domain.dart';
+import 'package:academia/core/core.dart';
+
+class GetEventByInviteUsecase {
+  final ShereheRepository repository;
+
+  GetEventByInviteUsecase(this.repository);
+
+  Future<Either<Failure, Event>> call({required String invite}) async {
+    return repository.getEventByInvite(invite: invite);
+  }
+}

--- a/lib/features/sherehe/domain/usecases/get_ticket_by_invite_usecase.dart
+++ b/lib/features/sherehe/domain/usecases/get_ticket_by_invite_usecase.dart
@@ -1,0 +1,13 @@
+import 'package:dartz/dartz.dart';
+import '../domain.dart';
+import 'package:academia/core/core.dart';
+
+class GetTicketByInviteUsecase {
+  final ShereheRepository repository;
+
+  GetTicketByInviteUsecase(this.repository);
+
+  Future<Either<Failure, Ticket>> call({required String invite}) async {
+    return repository.getTicketByInvite(invite: invite);
+  }
+}

--- a/lib/features/sherehe/presentation/bloc/sherehe_details_bloc.dart
+++ b/lib/features/sherehe/presentation/bloc/sherehe_details_bloc.dart
@@ -8,9 +8,12 @@ part 'sherehe_details_state.dart';
 class ShereheDetailsBloc
     extends Bloc<ShereheDetailsEvent, ShereheDetailsState> {
   final GetSpecificEvent getSpecificEventUseCase;
+  final GetEventByInviteUsecase getEventByInviteUsecase;
 
-  ShereheDetailsBloc({required this.getSpecificEventUseCase})
-    : super(ShereheDetailsInitial()) {
+  ShereheDetailsBloc({
+    required this.getSpecificEventUseCase,
+    required this.getEventByInviteUsecase,
+  }) : super(ShereheDetailsInitial()) {
     on<LoadShereheDetails>(_onLoadShereheDetails);
   }
 
@@ -23,10 +26,25 @@ class ShereheDetailsBloc
       return;
     }
 
+    if (event.invite != null) {
+      final result = await getEventByInviteUsecase(invite: event.invite!);
+
+      result.fold(
+        (failure) {
+          emit(ShereheDetailsError(message: failure.message));
+        },
+        (event) {
+          emit(ShereheDetailsLoaded(event: event));
+        },
+      );
+    }
+
+    // if initialEvent and invite are both null, then we try to fetch the event by id
+
     emit(ShereheDetailsLoading());
 
     final result = await getSpecificEventUseCase.execute(
-      eventId: event.eventId,
+      eventId: event.eventId ?? '',
     );
 
     result.fold(

--- a/lib/features/sherehe/presentation/bloc/sherehe_details_event.dart
+++ b/lib/features/sherehe/presentation/bloc/sherehe_details_event.dart
@@ -8,11 +8,12 @@ abstract class ShereheDetailsEvent extends Equatable {
 }
 
 class LoadShereheDetails extends ShereheDetailsEvent {
-  final String eventId;
+  final String? eventId;
   final Event? initialEvent;
+  final String? invite;
 
-  const LoadShereheDetails({required this.eventId, this.initialEvent});
+  const LoadShereheDetails({this.eventId, this.initialEvent, this.invite});
 
   @override
-  List<Object?> get props => [eventId, initialEvent];
+  List<Object?> get props => [eventId, initialEvent, invite];
 }

--- a/lib/features/sherehe/presentation/bloc/ticket_payment/ticket_payment_bloc.dart
+++ b/lib/features/sherehe/presentation/bloc/ticket_payment/ticket_payment_bloc.dart
@@ -33,21 +33,12 @@ class TicketPaymentBloc extends Bloc<TicketPaymentEvent, TicketPaymentState> {
 
     result.fold(
       (failure) {
-        emit(
-          PurchaseError(
-            message: failure.message,
-          ),
-        );
+        emit(PurchaseError(message: failure.message));
       },
       (success) {
         // FREE EVENT FLOW
         if (success is FreeTicketSuccess) {
-          emit(
-            FreeTicketBooked(
-              attendeeId: success.attendeeId,
-              message: success.message,
-            ),
-          );
+          emit(FreeTicketBooked(message: success.message));
         }
 
         // PAID EVENT FLOW

--- a/lib/features/sherehe/presentation/bloc/ticket_payment/ticket_payment_state.dart
+++ b/lib/features/sherehe/presentation/bloc/ticket_payment/ticket_payment_state.dart
@@ -31,13 +31,12 @@ class PurchaseError extends TicketPaymentState {
 }
 
 class FreeTicketBooked extends TicketPaymentState {
-  final String attendeeId;
   final String message;
 
-  const FreeTicketBooked({required this.attendeeId, required this.message});
+  const FreeTicketBooked({required this.message});
 
   @override
-  List<Object?> get props => [attendeeId, message];
+  List<Object?> get props => [message];
 }
 
 class ConfirmPaymentLoading extends TicketPaymentState {

--- a/lib/features/sherehe/presentation/bloc/user_ticket_selection/user_ticket_selection_bloc.dart
+++ b/lib/features/sherehe/presentation/bloc/user_ticket_selection/user_ticket_selection_bloc.dart
@@ -1,4 +1,3 @@
-import 'package:academia/features/institution/domain/usecases/get_all_cached_institutions_usecase.dart';
 import 'package:academia/features/sherehe/domain/domain.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -9,12 +8,9 @@ part 'user_ticket_selection_state.dart';
 class UserTicketSelectionBloc
     extends Bloc<UserTicketSelectionEvent, UserTicketSelectionState> {
   final GetTicketsByEventIdUseCase getTicketsByEventId;
-  final GetAllCachedInstitutionsUsecase getAllCachedInstitutions;
 
-  UserTicketSelectionBloc({
-    required this.getTicketsByEventId,
-    required this.getAllCachedInstitutions,
-  }) : super(UserTicketInitial()) {
+  UserTicketSelectionBloc({required this.getTicketsByEventId})
+    : super(UserTicketInitial()) {
     on<FetchTicketsByEventId>(_onFetchTicketsByEventId);
   }
 
@@ -26,29 +22,9 @@ class UserTicketSelectionBloc
 
     final ticketsResult = await getTicketsByEventId(eventID: event.eventId);
 
-    final institutionsResult = await getAllCachedInstitutions(event.accountId);
-
-    institutionsResult.fold(
+    ticketsResult.fold(
       (failure) => emit(UserTicketError(failure.message)),
-      (userInstitutions) {
-        final userInstitutionIds = userInstitutions
-            .map((e) => e.institutionId)
-            .toSet();
-        ticketsResult.fold(
-          (failure) => emit(UserTicketError(failure.message)),
-          (tickets) {
-            final filteredTickets = tickets.where((ticket) {
-              final visibility = ticket.institutionIds;
-
-              if (visibility == null || visibility.isEmpty) return true;
-
-              return visibility.any(userInstitutionIds.contains);
-            }).toList();
-
-            emit(UserTicketLoaded(tickets: filteredTickets));
-          },
-        );
-      },
+      (tickets) => emit(UserTicketLoaded(tickets: tickets)),
     );
   }
 }

--- a/lib/features/sherehe/presentation/bloc/user_ticket_selection/user_ticket_selection_bloc.dart
+++ b/lib/features/sherehe/presentation/bloc/user_ticket_selection/user_ticket_selection_bloc.dart
@@ -8,19 +8,35 @@ part 'user_ticket_selection_state.dart';
 class UserTicketSelectionBloc
     extends Bloc<UserTicketSelectionEvent, UserTicketSelectionState> {
   final GetTicketsByEventIdUseCase getTicketsByEventId;
+  final GetTicketByInviteUsecase getTicketsByInvite;
 
-  UserTicketSelectionBloc({required this.getTicketsByEventId})
-    : super(UserTicketInitial()) {
-    on<FetchTicketsByEventId>(_onFetchTicketsByEventId);
+  UserTicketSelectionBloc({
+    required this.getTicketsByEventId,
+    required this.getTicketsByInvite,
+  }) : super(UserTicketInitial()) {
+    on<FetchTickets>(_onFetchTickets);
   }
 
-  Future<void> _onFetchTicketsByEventId(
-    FetchTicketsByEventId event,
+  Future<void> _onFetchTickets(
+    FetchTickets event,
     Emitter<UserTicketSelectionState> emit,
   ) async {
     emit(UserTicketLoading());
 
-    final ticketsResult = await getTicketsByEventId(eventID: event.eventId);
+    if (event.invite != null) {
+      final result = await getTicketsByInvite(invite: event.invite!);
+
+      result.fold(
+        (failure) => emit(UserTicketError(failure.message)),
+        (ticket) => emit(UserTicketLoaded(tickets: [ticket])),
+      );
+    }
+
+    // if invite is null, then we try to fetch the tickets by event id. This is the case when the user accesses the page via the sherehe details page
+
+    final ticketsResult = await getTicketsByEventId(
+      eventID: event.eventId ?? '',
+    );
 
     ticketsResult.fold(
       (failure) => emit(UserTicketError(failure.message)),

--- a/lib/features/sherehe/presentation/bloc/user_ticket_selection/user_ticket_selection_event.dart
+++ b/lib/features/sherehe/presentation/bloc/user_ticket_selection/user_ticket_selection_event.dart
@@ -7,11 +7,12 @@ abstract class UserTicketSelectionEvent extends Equatable {
   List<Object?> get props => [];
 }
 
-class FetchTicketsByEventId extends UserTicketSelectionEvent {
-  final String eventId;
+class FetchTickets extends UserTicketSelectionEvent {
+  final String? eventId;
+  final String? invite;
 
-  const FetchTicketsByEventId({required this.eventId});
+  const FetchTickets({this.eventId, this.invite});
 
   @override
-  List<Object?> get props => [eventId];
+  List<Object?> get props => [eventId, invite];
 }

--- a/lib/features/sherehe/presentation/bloc/user_ticket_selection/user_ticket_selection_event.dart
+++ b/lib/features/sherehe/presentation/bloc/user_ticket_selection/user_ticket_selection_event.dart
@@ -9,9 +9,8 @@ abstract class UserTicketSelectionEvent extends Equatable {
 
 class FetchTicketsByEventId extends UserTicketSelectionEvent {
   final String eventId;
-  final String accountId;
 
-  const FetchTicketsByEventId({required this.eventId, required this.accountId});
+  const FetchTicketsByEventId({required this.eventId});
 
   @override
   List<Object?> get props => [eventId];

--- a/lib/features/sherehe/presentation/presentation.dart
+++ b/lib/features/sherehe/presentation/presentation.dart
@@ -53,5 +53,7 @@ export 'widgets/event_visibility_selector.dart';
 export 'widgets/event_image_helper_text_widget.dart';
 export 'widgets/user_tile.dart';
 export 'widgets/added_tickets_card.dart';
+export 'widgets/user_ticket_item_card.dart';
+export 'widgets/ticket_quantity_selector.dart';
 export 'utils/sherehe_utils.dart';
 export 'constants/sherehe_constants.dart';

--- a/lib/features/sherehe/presentation/presentation.dart
+++ b/lib/features/sherehe/presentation/presentation.dart
@@ -55,5 +55,6 @@ export 'widgets/user_tile.dart';
 export 'widgets/added_tickets_card.dart';
 export 'widgets/user_ticket_item_card.dart';
 export 'widgets/ticket_quantity_selector.dart';
+export 'widgets/sherehe_details_schedule_card.dart';
 export 'utils/sherehe_utils.dart';
 export 'constants/sherehe_constants.dart';

--- a/lib/features/sherehe/presentation/screens/create_event_screen.dart
+++ b/lib/features/sherehe/presentation/screens/create_event_screen.dart
@@ -475,15 +475,8 @@ class _CreateEventScreenState extends State<CreateEventScreen> {
       body: BlocListener<CreateEventBloc, CreateEventState>(
         listener: (context, state) {
           if (state is CreateEventSuccess) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text("Event created successfully!"),
-                behavior: SnackBarBehavior.floating,
-              ),
-            );
-            context.read<ShereheHomeBloc>().add(FetchAllEvents(page: 1));
             if (context.canPop()) {
-              context.pop(true);
+              context.pop(state.event);
             }
           } else if (state is CreateEventFailure) {
             ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/sherehe/presentation/screens/sherehe_details_page.dart
+++ b/lib/features/sherehe/presentation/screens/sherehe_details_page.dart
@@ -13,10 +13,11 @@ import 'package:dio/dio.dart';
 import 'package:path_provider/path_provider.dart';
 
 class ShereheDetailsPage extends StatefulWidget {
-  final String eventId;
+  final String? eventId;
   final Event? event;
+  final String? invite;
 
-  const ShereheDetailsPage({super.key, required this.eventId, this.event});
+  const ShereheDetailsPage({super.key, this.eventId, this.event, this.invite});
 
   @override
   State<ShereheDetailsPage> createState() => _ShereheDetailsPageState();
@@ -35,12 +36,18 @@ class _ShereheDetailsPageState extends State<ShereheDetailsPage> {
     }
 
     context.read<ShereheDetailsBloc>().add(
-      LoadShereheDetails(eventId: widget.eventId, initialEvent: widget.event),
+      LoadShereheDetails(
+        eventId: widget.eventId ?? '',
+        initialEvent: widget.event,
+        invite: widget.invite,
+      ),
     );
 
-    context.read<GetEventScannerByUserIdBloc>().add(
-      GetEventScannerByUserId(eventId: widget.eventId),
-    );
+    if (widget.eventId != null) {
+      context.read<GetEventScannerByUserIdBloc>().add(
+        GetEventScannerByUserId(eventId: widget.eventId!),
+      );
+    }
   }
 
   double _getExpandedHeight(BuildContext context) {
@@ -99,14 +106,21 @@ class _ShereheDetailsPageState extends State<ShereheDetailsPage> {
             ),
           );
         } else if (state is ShereheDetailsLoaded) {
+          // If the page was accessed via an invite link, we also fetch the scanner info to determine if the user can access the scanning feature
+          if (widget.invite != null) {
+            context.read<GetEventScannerByUserIdBloc>().add(
+              GetEventScannerByUserId(eventId: state.event.id),
+            );
+          }
+
           DateTime normalize(DateTime d) => DateTime(d.year, d.month, d.day);
 
-          final eventDate = normalize(
-            DateTime.parse(state.event.startDate).toLocal(),
+          final eventEndDate = normalize(
+            DateTime.parse(state.event.endDate).toLocal(),
           );
           final today = normalize(DateTime.now());
 
-          final isPastEvent = today.isAfter(eventDate);
+          final isPastEvent = today.isAfter(eventEndDate);
           return Scaffold(
             body: CustomScrollView(
               slivers: [
@@ -488,7 +502,6 @@ class _ShereheDetailsPageState extends State<ShereheDetailsPage> {
                         : () {
                             TicketFlowRoute(
                               eventId: state.event.id,
-                              userId: userId ?? '',
                             ).push(context);
                           },
                     child: const Text("I'm Going"),

--- a/lib/features/sherehe/presentation/screens/sherehe_details_page.dart
+++ b/lib/features/sherehe/presentation/screens/sherehe_details_page.dart
@@ -118,6 +118,7 @@ class _ShereheDetailsPageState extends State<ShereheDetailsPage> {
           final eventEndDate = normalize(
             DateTime.parse(state.event.endDate).toLocal(),
           );
+
           final today = normalize(DateTime.now());
 
           final isPastEvent = today.isAfter(eventEndDate);
@@ -339,127 +340,109 @@ class _ShereheDetailsPageState extends State<ShereheDetailsPage> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              'About Event',
-                              style:
-                                  ResponsiveBreakPoints.isTablet(context) ||
-                                      ResponsiveBreakPoints.isDesktop(context)
-                                  ? Theme.of(
-                                      context,
-                                    ).textTheme.headlineMedium!.copyWith(
-                                      fontWeight: FontWeight.bold,
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.onSurface,
-                                    )
-                                  : Theme.of(
-                                      context,
-                                    ).textTheme.headlineSmall!.copyWith(
-                                      fontWeight: FontWeight.bold,
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.onSurface,
-                                    ),
-                            ),
-                            const SizedBox(height: 12),
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Wrap(
-                                  spacing: 8,
-                                  runSpacing: 8,
-                                  children: state.event.eventGenre!
-                                      .map((e) => e.trim())
-                                      .map(
-                                        (genre) => Chip(
-                                          shape: RoundedRectangleBorder(
-                                            borderRadius: BorderRadius.circular(
-                                              20,
-                                            ),
-                                          ),
-                                          backgroundColor: Theme.of(
-                                            context,
-                                          ).colorScheme.secondaryContainer,
-                                          label: Text(
-                                            genre,
-                                            style: TextStyle(
-                                              color: Theme.of(context)
-                                                  .colorScheme
-                                                  .onSecondaryContainer,
-                                              fontWeight: FontWeight.w600,
-                                            ),
-                                          ),
-                                        ),
-                                      )
-                                      .toList(),
-                                ),
-                                const SizedBox(height: 16),
-                              ],
-                            ),
-                            Text(
-                              _normalizeDescription(
-                                state.event.eventDescription,
-                              ),
-                              style:
-                                  ResponsiveBreakPoints.isTablet(context) ||
-                                      ResponsiveBreakPoints.isDesktop(context)
-                                  ? Theme.of(
-                                      context,
-                                    ).textTheme.bodyLarge!.copyWith(
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.onSurfaceVariant,
-                                      height: 1.5,
-                                    )
-                                  : Theme.of(
-                                      context,
-                                    ).textTheme.bodyMedium!.copyWith(
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.onSurfaceVariant,
-                                      height: 1.5,
-                                    ),
-                            ),
-                          ],
+                        Text(
+                          'About Event',
+                          style:
+                              ResponsiveBreakPoints.isTablet(context) ||
+                                  ResponsiveBreakPoints.isDesktop(context)
+                              ? Theme.of(context).textTheme.headlineMedium!
+                                    .copyWith(fontWeight: FontWeight.bold)
+                              : Theme.of(context).textTheme.headlineSmall!
+                                    .copyWith(fontWeight: FontWeight.bold),
                         ),
+
+                        const SizedBox(height: 12),
+
+                        if (state.event.eventGenre != null &&
+                            state.event.eventGenre!.isNotEmpty)
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: state.event.eventGenre!
+                                .map((e) => e.trim())
+                                .map(
+                                  (genre) => Chip(
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(20),
+                                    ),
+                                    backgroundColor: Theme.of(
+                                      context,
+                                    ).colorScheme.secondaryContainer,
+                                    label: Text(
+                                      genre,
+                                      style: TextStyle(
+                                        color: Theme.of(
+                                          context,
+                                        ).colorScheme.onSecondaryContainer,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                          ),
+
                         const SizedBox(height: 16),
-                        Row(
-                          children: [
-                            const Icon(Icons.location_on),
-                            const SizedBox(width: 8),
-                            Expanded(child: Text(state.event.eventLocation)),
-                          ],
+
+                        Text(
+                          _normalizeDescription(state.event.eventDescription),
+                          style:
+                              ResponsiveBreakPoints.isTablet(context) ||
+                                  ResponsiveBreakPoints.isDesktop(context)
+                              ? Theme.of(context).textTheme.bodyLarge!.copyWith(
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
+                                  height: 1.5,
+                                )
+                              : Theme.of(
+                                  context,
+                                ).textTheme.bodyMedium!.copyWith(
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
+                                  height: 1.5,
+                                ),
                         ),
-                        const SizedBox(height: 8),
-                        Row(
-                          spacing: 16.0,
-                          children: [
-                            Row(
-                              spacing: 8.0,
+                        const SizedBox(height: 10),
+                        Card(
+                          elevation: 1,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.all(16),
+                            child: Column(
                               children: [
-                                const Icon(Icons.calendar_month),
-                                Text(
-                                  ShereheUtils.formatDate(
-                                    state.event.startDate,
-                                  ),
+                                Row(
+                                  children: [
+                                    Icon(
+                                      Icons.location_on,
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.primary,
+                                    ),
+                                    const SizedBox(width: 12),
+                                    Expanded(
+                                      child: Text(
+                                        state.event.eventLocation,
+                                        style: Theme.of(
+                                          context,
+                                        ).textTheme.bodyMedium,
+                                      ),
+                                    ),
+                                  ],
                                 ),
                               ],
                             ),
-                            Row(
-                              spacing: 8.0,
-                              children: [
-                                const Icon(Icons.access_time),
-                                Text(
-                                  ShereheUtils.formatTime(
-                                    state.event.startDate,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ],
+                          ),
+                        ),
+
+                        const SizedBox(height: 16),
+
+                        ShereheDetailsScheduleCard(
+                          startDate: state.event.startDate,
+                          endDate: state.event.endDate,
                         ),
                       ],
                     ),

--- a/lib/features/sherehe/presentation/screens/sherehe_home.dart
+++ b/lib/features/sherehe/presentation/screens/sherehe_home.dart
@@ -1,6 +1,7 @@
 import 'package:academia/config/config.dart';
 import 'package:academia/core/core.dart';
 import 'package:academia/features/admob/admob.dart';
+import 'package:academia/features/profile/presentation/bloc/profile_bloc.dart';
 import 'package:academia/features/sherehe/domain/domain.dart';
 import 'package:academia/features/sherehe/presentation/presentation.dart';
 import 'package:flutter/material.dart';
@@ -20,6 +21,7 @@ class _ShereheHomeState extends State<ShereheHome>
   final ScrollController _scrollController = ScrollController();
   int _currentPage = 1;
   static const int adInterval = 3;
+  String? _userEmail;
 
   @override
   bool get wantKeepAlive => true;
@@ -27,6 +29,10 @@ class _ShereheHomeState extends State<ShereheHome>
   @override
   void initState() {
     super.initState();
+    final profileState = context.read<ProfileBloc>().state;
+    if (profileState is ProfileLoadedState) {
+      _userEmail = profileState.profile.email;
+    }
     context.read<ShereheHomeBloc>().add(FetchAllEvents(page: _currentPage));
     _scrollController.addListener(_onScroll);
   }
@@ -252,8 +258,104 @@ class _ShereheHomeState extends State<ShereheHome>
         onPressed: () async {
           final result = await CreateEventRoute().push(context);
 
-          if (result == true) {
-            _resetAndReload();
+          if (!context.mounted) return;
+
+          if (result is! Event) return;
+
+          _resetAndReload();
+          final maskedEmail = ShereheUtils.maskEmail(_userEmail ?? '');
+          final scope = ScopeTypesX.fromBackend(result.scope);
+          final isPrivateEvent = scope == ScopeTypes.private;
+
+          if (isPrivateEvent) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!context.mounted) return;
+
+              showDialog(
+                context: context,
+                builder: (context) => Dialog(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(24),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 24,
+                      vertical: 28,
+                    ),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.all(16),
+                          decoration: BoxDecoration(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.primaryContainer,
+                            shape: BoxShape.circle,
+                          ),
+                          child: Icon(
+                            Icons.lock_outline,
+                            size: 32,
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onPrimaryContainer,
+                          ),
+                        ),
+
+                        const SizedBox(height: 20),
+
+                        Text(
+                          "Private Event Created",
+                          style: Theme.of(context).textTheme.titleLarge
+                              ?.copyWith(fontWeight: FontWeight.w600),
+                          textAlign: TextAlign.center,
+                        ),
+
+                        const SizedBox(height: 12),
+
+                        Text(
+                          "Your private event has been created successfully.\n\n"
+                          "A secure link has been sent to:\n$maskedEmail\n\n"
+                          "Please check your inbox to access it.",
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                              ),
+                          textAlign: TextAlign.center,
+                        ),
+
+                        const SizedBox(height: 24),
+
+                        SizedBox(
+                          width: double.infinity,
+                          child: FilledButton(
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                            },
+                            style: FilledButton.styleFrom(
+                              padding: const EdgeInsets.symmetric(vertical: 14),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(14),
+                              ),
+                            ),
+                            child: const Text("Got it"),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            });
+          } else {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text("Event created successfully!"),
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
           }
         },
         tooltip: "Create Event",

--- a/lib/features/sherehe/presentation/screens/ticket_flow_page.dart
+++ b/lib/features/sherehe/presentation/screens/ticket_flow_page.dart
@@ -7,14 +7,10 @@ import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class TicketFlowPage extends StatefulWidget {
-  final String eventId;
-  final String userId;
+  final String? eventId;
+  final String? invite;
 
-  const TicketFlowPage({
-    super.key,
-    required this.eventId,
-    required this.userId,
-  });
+  const TicketFlowPage({super.key, this.eventId, this.invite});
 
   @override
   State<TicketFlowPage> createState() => _TicketFlowPageState();
@@ -32,7 +28,7 @@ class _TicketFlowPageState extends State<TicketFlowPage> {
   void initState() {
     super.initState();
     context.read<UserTicketSelectionBloc>().add(
-      FetchTicketsByEventId(eventId: widget.eventId),
+      FetchTickets(eventId: widget.eventId, invite: widget.invite),
     );
     context.read<TicketPaymentBloc>().add(ResetTicketPaymentState());
   }
@@ -298,7 +294,7 @@ class _TicketFlowPageState extends State<TicketFlowPage> {
           onPageChanged: (index) => setState(() => currentPage = index),
           children: [
             UserTicketSelectionPage(
-              eventId: widget.eventId,
+              eventId: widget.eventId ?? '',
               selectedTicket: _selectedTicket,
               quantity: _quantity,
               onTicketSelected: (ticket) {

--- a/lib/features/sherehe/presentation/screens/ticket_flow_page.dart
+++ b/lib/features/sherehe/presentation/screens/ticket_flow_page.dart
@@ -32,7 +32,7 @@ class _TicketFlowPageState extends State<TicketFlowPage> {
   void initState() {
     super.initState();
     context.read<UserTicketSelectionBloc>().add(
-      FetchTicketsByEventId(eventId: widget.eventId, accountId: widget.userId),
+      FetchTicketsByEventId(eventId: widget.eventId),
     );
     context.read<TicketPaymentBloc>().add(ResetTicketPaymentState());
   }
@@ -192,7 +192,7 @@ class _TicketFlowPageState extends State<TicketFlowPage> {
                 SnackBar(
                   content: Text(
                     "Ticket booked successfully 🎉"
-                    "\nFind it under the menu (⋮) in the top right, " 
+                    "\nFind it under the menu (⋮) in the top right, "
                     "then tap 'My Tickets'.",
                   ),
                   duration: const Duration(seconds: 6),

--- a/lib/features/sherehe/presentation/screens/ticket_selection_page.dart
+++ b/lib/features/sherehe/presentation/screens/ticket_selection_page.dart
@@ -89,6 +89,7 @@ class _TicketSelectionPageState extends State<TicketSelectionPage> {
       _ticketQtyController.clear();
       _selectedTicketGroupType = null;
       _selectedInstitutions.clear();
+      _selectedScopeType = null;
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/lib/features/sherehe/presentation/screens/user_ticket_selection_page.dart
+++ b/lib/features/sherehe/presentation/screens/user_ticket_selection_page.dart
@@ -131,163 +131,24 @@ class _UserTicketSelectionPageState extends State<UserTicketSelectionPage> {
                   // Ticket list - only visible for paid events
                   if (!isFreeEvent) ...[
                     ...sortedTickets.map((ticket) {
-                      final isSelected = widget.selectedTicket == ticket;
-                      return GestureDetector(
-                        onTap: ticket.ticketQuantity == 0
-                            ? null
-                            : () {
-                                widget.onTicketSelected(ticket);
-
-                                // Wait for UI to rebuild before scrolling
-                                WidgetsBinding.instance.addPostFrameCallback((
-                                  _,
-                                ) {
-                                  if (!_scrollController.hasClients) return;
-
-                                  _scrollController.animateTo(
-                                    _scrollController.position.maxScrollExtent,
-                                    duration: const Duration(milliseconds: 400),
-                                    curve: Curves.easeOut,
-                                  );
-                                });
-                              },
-                        child: Opacity(
-                          opacity: ticket.ticketQuantity == 0 ? 0.5 : 1.0,
-                          child: Card(
-                            elevation: isSelected ? 6 : 1,
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
-                              side: isSelected
-                                  ? BorderSide(
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.primary,
-                                      width: 2,
-                                    )
-                                  : BorderSide.none,
-                            ),
-                            child: ListTile(
-                              title: Text(ticket.ticketName),
-                              subtitle: Text(
-                                ticket.ticketQuantity == 0
-                                    ? "Sold Out"
-                                    : "KES ${ticket.ticketPrice.toStringAsFixed(0)}",
-                              ),
-                              trailing: Icon(
-                                isSelected
-                                    ? Icons.check_circle
-                                    : Icons.circle_outlined,
-                                color: isSelected
-                                    ? Theme.of(context).colorScheme.primary
-                                    : null,
-                              ),
-                            ),
-                          ),
-                        ),
+                      return UserTicketItemCard(
+                        ticket: ticket,
+                        isSelected: widget.selectedTicket == ticket,
+                        onTicketSelected: widget.onTicketSelected,
+                        scrollController: _scrollController,
                       );
                     }),
                   ],
 
                   // Quantity selector appears for both free + paid
                   if (widget.selectedTicket != null)
-                    Container(
-                      padding: const EdgeInsets.all(16),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(16),
-                        color: Theme.of(
-                          context,
-                        ).colorScheme.surfaceContainerHighest,
-                      ),
-                      child: Column(
-                        spacing: 12.0,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            isFreeEvent
-                                ? "Select Free Ticket Quantity"
-                                : "Select Quantity",
-                            style: Theme.of(context).textTheme.titleMedium,
-                          ),
-
-                          // Quantity controls
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              IconButton(
-                                onPressed: widget.quantity > 1
-                                    ? () => widget.onQuantityChanged(
-                                        widget.quantity - 1,
-                                      )
-                                    : null,
-                                icon: const Icon(Icons.remove_circle_outline),
-                              ),
-                              Text(
-                                widget.quantity.toString(),
-                                style: Theme.of(
-                                  context,
-                                ).textTheme.headlineSmall,
-                              ),
-                              IconButton(
-                                onPressed: widget.quantity < maxAllowedQuantity
-                                    ? () => widget.onQuantityChanged(
-                                        widget.quantity + 1,
-                                      )
-                                    : null,
-                                icon: const Icon(Icons.add_circle_outline),
-                              ),
-                            ],
-                          ),
-                          if (widget.quantity == maxAllowedQuantity &&
-                              maxAllowedQuantity > 0)
-                            Padding(
-                              padding: const EdgeInsets.only(top: 4),
-                              child: Text(
-                                widget.quantity == 2 &&
-                                        (widget
-                                                    .selectedTicket!
-                                                    .ticketQuantity ??
-                                                0) >
-                                            2
-                                    ? "Maximum of 2 tickets can be purchased"
-                                    : "Only ${widget.selectedTicket!.ticketQuantity} ${widget.selectedTicket!.ticketQuantity == 1 ? "ticket" : "tickets"} remaining",
-                                style: Theme.of(context).textTheme.bodySmall
-                                    ?.copyWith(
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.error,
-                                    ),
-                              ),
-                            ),
-
-                          if (widget.selectedTicket!.ticketQuantity == 0)
-                            Padding(
-                              padding: const EdgeInsets.only(top: 4),
-                              child: Text(
-                                "Sorry this ticket is sold out.",
-                                style: Theme.of(context).textTheme.bodySmall
-                                    ?.copyWith(
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.error,
-                                    ),
-                              ),
-                            ),
-
-                          // Continue button
-                          SizedBox(
-                            width: double.infinity,
-                            child: FilledButton(
-                              onPressed:
-                                  widget.selectedTicket!.ticketQuantity == 0
-                                  ? null
-                                  : widget.onContinue,
-                              child: Text(
-                                isFreeEvent ? "Continue (Free)" : "Continue",
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
+                    TicketQuantitySelector(
+                      isFreeEvent: isFreeEvent,
+                      selectedTicket: widget.selectedTicket!,
+                      quantity: widget.quantity,
+                      maxAllowedQuantity: maxAllowedQuantity,
+                      onQuantityChanged: widget.onQuantityChanged,
+                      onContinue: widget.onContinue,
                     ),
                 ],
               ),

--- a/lib/features/sherehe/presentation/utils/sherehe_utils.dart
+++ b/lib/features/sherehe/presentation/utils/sherehe_utils.dart
@@ -155,4 +155,19 @@ class ShereheUtils {
           ),
     );
   }
+
+  static String maskEmail(String email) {
+    final parts = email.split('@');
+    if (parts.length != 2) return email;
+
+    final name = parts[0];
+    final domain = parts[1];
+
+    if (name.length <= 2) {
+      return '${name[0]}***@$domain';
+    }
+
+    final visible = name.substring(0, 2);
+    return '$visible****@$domain';
+  }
 }

--- a/lib/features/sherehe/presentation/widgets/sherehe_details_schedule_card.dart
+++ b/lib/features/sherehe/presentation/widgets/sherehe_details_schedule_card.dart
@@ -1,0 +1,214 @@
+import 'package:academia/features/sherehe/presentation/utils/sherehe_utils.dart';
+import 'package:flutter/material.dart';
+
+class ShereheDetailsScheduleCard extends StatelessWidget {
+  final String startDate;
+  final String endDate;
+
+  const ShereheDetailsScheduleCard({
+    super.key,
+    required this.startDate,
+    required this.endDate,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final start = DateTime.parse(startDate).toLocal();
+    final end = DateTime.parse(endDate).toLocal();
+
+    final isSameDay =
+        start.year == end.year &&
+        start.month == end.month &&
+        start.day == end.day;
+
+    return Card(
+      elevation: 1,
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          spacing: 16,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header
+            Row(
+              children: [
+                Icon(
+                  Icons.calendar_month,
+                  color: Theme.of(context).colorScheme.onPrimaryContainer,
+                  size: 20,
+                ),
+                const SizedBox(width: 12),
+                Text(
+                  "Event Schedule",
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+            if (isSameDay)
+              _SameDayView(startDate: startDate, endDate: endDate)
+            else
+              _MultiDayTimeline(startDate: startDate, endDate: endDate),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SameDayView extends StatelessWidget {
+  final String startDate;
+  final String endDate;
+
+  const _SameDayView({required this.startDate, required this.endDate});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          ShereheUtils.formatDate(startDate),
+          style: Theme.of(
+            context,
+          ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 6),
+        Row(
+          children: [
+            Icon(
+              Icons.access_time,
+              size: 18,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(width: 6),
+            Text(
+              "${ShereheUtils.formatTime(startDate)} - ${ShereheUtils.formatTime(endDate)}",
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _MultiDayTimeline extends StatelessWidget {
+  final String startDate;
+  final String endDate;
+
+  const _MultiDayTimeline({required this.startDate, required this.endDate});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        children: [
+          _TimelineItem(
+            label: "Starts",
+            date: ShereheUtils.formatDate(startDate),
+            time: ShereheUtils.formatTime(startDate),
+            isTop: true,
+          ),
+          _TimelineDivider(),
+          _TimelineItem(
+            label: "Ends",
+            date: ShereheUtils.formatDate(endDate),
+            time: ShereheUtils.formatTime(endDate),
+            isTop: false,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TimelineItem extends StatelessWidget {
+  final String label;
+  final String date;
+  final String time;
+  final bool isTop;
+
+  const _TimelineItem({
+    required this.label,
+    required this.date,
+    required this.time,
+    required this.isTop,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Timeline indicator
+        Column(
+          children: [
+            Container(
+              width: 10,
+              height: 10,
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary,
+                shape: BoxShape.circle,
+              ),
+            ),
+            if (isTop)
+              Container(
+                width: 2,
+                height: 40,
+                color: Theme.of(context).colorScheme.outlineVariant,
+              ),
+          ],
+        ),
+
+        const SizedBox(width: 12),
+
+        // Content
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                date,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600),
+              ),
+              Text(
+                time,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TimelineDivider extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 4),
+      child: Container(
+        width: 2,
+        height: 12,
+        color: Theme.of(context).colorScheme.outlineVariant,
+      ),
+    );
+  }
+}

--- a/lib/features/sherehe/presentation/widgets/ticket_quantity_selector.dart
+++ b/lib/features/sherehe/presentation/widgets/ticket_quantity_selector.dart
@@ -1,0 +1,136 @@
+import 'package:academia/features/sherehe/domain/entities/ticket.dart';
+import 'package:flutter/material.dart';
+
+class TicketQuantitySelector extends StatelessWidget {
+  final bool isFreeEvent;
+  final Ticket selectedTicket;
+  final int quantity;
+  final int maxAllowedQuantity;
+  final Function(int) onQuantityChanged;
+  final VoidCallback onContinue;
+
+  const TicketQuantitySelector({
+    super.key,
+    required this.isFreeEvent,
+    required this.selectedTicket,
+    required this.quantity,
+    required this.maxAllowedQuantity,
+    required this.onQuantityChanged,
+    required this.onContinue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ticket = selectedTicket;
+    final totalPeople = quantity * ticket.ticketFor;
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            isFreeEvent ? "Select Free Ticket Quantity" : "Select Quantity",
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+
+          const SizedBox(height: 12),
+
+          // Quantity controls
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              IconButton(
+                onPressed: quantity > 1
+                    ? () => onQuantityChanged(quantity - 1)
+                    : null,
+                icon: const Icon(Icons.remove_circle_outline),
+              ),
+              Text(
+                quantity.toString(),
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              IconButton(
+                onPressed: quantity < maxAllowedQuantity
+                    ? () => onQuantityChanged(quantity + 1)
+                    : null,
+                icon: const Icon(Icons.add_circle_outline),
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 8),
+
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Theme.of(
+                context,
+              ).colorScheme.primaryContainer.withOpacity(0.4),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.groups_2_outlined,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    "Covers $totalPeople ${totalPeople == 1 ? "person" : "people"}",
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // Max quantity warning
+          if (quantity == maxAllowedQuantity && maxAllowedQuantity > 0)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                quantity == 2 && (ticket.ticketQuantity ?? 0) > 2
+                    ? "Maximum of 2 tickets can be purchased"
+                    : "Only ${ticket.ticketQuantity} ${ticket.ticketQuantity == 1 ? "ticket" : "tickets"} remaining",
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.error,
+                ),
+              ),
+            ),
+
+          // Sold out message
+          if (ticket.ticketQuantity == 0)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                "Sorry this ticket is sold out.",
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.error,
+                ),
+              ),
+            ),
+
+          const SizedBox(height: 12),
+
+          // Continue button
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: ticket.ticketQuantity == 0 ? null : onContinue,
+              child: Text(isFreeEvent ? "Continue (Free)" : "Continue"),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/sherehe/presentation/widgets/ticket_quantity_selector.dart
+++ b/lib/features/sherehe/presentation/widgets/ticket_quantity_selector.dart
@@ -22,7 +22,7 @@ class TicketQuantitySelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ticket = selectedTicket;
-    final totalPeople = quantity * ticket.ticketFor;
+    final totalPeople = quantity * (ticket.ticketFor ?? 0);
 
     return Container(
       padding: const EdgeInsets.all(16),

--- a/lib/features/sherehe/presentation/widgets/user_ticket_item_card.dart
+++ b/lib/features/sherehe/presentation/widgets/user_ticket_item_card.dart
@@ -1,0 +1,83 @@
+import 'package:academia/features/sherehe/domain/entities/ticket.dart';
+import 'package:flutter/material.dart';
+
+class UserTicketItemCard extends StatelessWidget {
+  final Ticket ticket;
+  final bool isSelected;
+  final Function(Ticket) onTicketSelected;
+  final ScrollController scrollController;
+
+  const UserTicketItemCard({
+    super.key,
+    required this.ticket,
+    required this.isSelected,
+    required this.onTicketSelected,
+    required this.scrollController,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: ticket.ticketQuantity == 0
+          ? null
+          : () {
+              onTicketSelected(ticket);
+
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (!scrollController.hasClients) return;
+
+                scrollController.animateTo(
+                  scrollController.position.maxScrollExtent,
+                  duration: const Duration(milliseconds: 400),
+                  curve: Curves.easeOut,
+                );
+              });
+            },
+      child: Opacity(
+        opacity: ticket.ticketQuantity == 0 ? 0.5 : 1.0,
+        child: Card(
+          elevation: isSelected ? 6 : 1,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: isSelected
+                ? BorderSide(
+                    color: Theme.of(context).colorScheme.primary,
+                    width: 2,
+                  )
+                : BorderSide.none,
+          ),
+          child: ListTile(
+            leading: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primaryContainer,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                "${ticket.ticketFor} ${ticket.ticketFor == 1 ? "Person" : "People"}",
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onPrimaryContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            title: Text(
+              ticket.ticketName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            subtitle: Text(
+              ticket.ticketQuantity == 0
+                  ? "Sold Out"
+                  : "KES ${ticket.ticketPrice.toStringAsFixed(0)}",
+            ),
+            trailing: Icon(
+              isSelected ? Icons.check_circle : Icons.circle_outlined,
+              color: isSelected ? Theme.of(context).colorScheme.primary : null,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/injection_container.dart
+++ b/lib/injection_container.dart
@@ -119,6 +119,8 @@ Future<void> init(FlavorConfig flavor, {bool isBackground = false}) async {
   sl.registerLazySingleton(() => ConfirmPaymentUseCase(sl()));
   sl.registerLazySingleton(() => GetAllUserPurchasedTicketsUseCase(sl()));
   sl.registerLazySingleton(() => SearchUserAttendedEventsUseCase(sl()));
+  sl.registerLazySingleton(() => GetTicketByInviteUsecase(sl()));
+  sl.registerLazySingleton(() => GetEventByInviteUsecase(sl()));
 
   sl.registerLazySingleton(() => GetUserPurchasedTicketsForEventUseCase(sl()));
 
@@ -139,7 +141,12 @@ Future<void> init(FlavorConfig flavor, {bool isBackground = false}) async {
 
   sl.registerFactory(() => ShereheHomeBloc(getEvent: sl()));
 
-  sl.registerFactory(() => ShereheDetailsBloc(getSpecificEventUseCase: sl()));
+  sl.registerFactory(
+    () => ShereheDetailsBloc(
+      getSpecificEventUseCase: sl(),
+      getEventByInviteUsecase: sl(),
+    ),
+  );
   sl.registerFactory(
     () => GetEventScannerByUserIdBloc(getEventScannerByUserId: sl()),
   );
@@ -149,7 +156,12 @@ Future<void> init(FlavorConfig flavor, {bool isBackground = false}) async {
   );
 
   sl.registerFactory(() => CreateEventBloc(createEventUseCase: sl()));
-  sl.registerFactory(() => UserTicketSelectionBloc(getTicketsByEventId: sl()));
+  sl.registerFactory(
+    () => UserTicketSelectionBloc(
+      getTicketsByEventId: sl(),
+      getTicketsByInvite: sl(),
+    ),
+  );
   sl.registerFactory(
     () => TicketPaymentBloc(purchaseTicket: sl(), confirmPayment: sl()),
   );

--- a/lib/injection_container.dart
+++ b/lib/injection_container.dart
@@ -149,12 +149,7 @@ Future<void> init(FlavorConfig flavor, {bool isBackground = false}) async {
   );
 
   sl.registerFactory(() => CreateEventBloc(createEventUseCase: sl()));
-  sl.registerFactory(
-    () => UserTicketSelectionBloc(
-      getTicketsByEventId: sl(),
-      getAllCachedInstitutions: sl(),
-    ),
-  );
+  sl.registerFactory(() => UserTicketSelectionBloc(getTicketsByEventId: sl()));
   sl.registerFactory(
     () => TicketPaymentBloc(purchaseTicket: sl(), confirmPayment: sl()),
   );


### PR DESCRIPTION
- Bumped up schema version from 29 to 30
- Worked on a descriptive dialogue telling event organizer they will receive an email with invite for a private event creation
- Prepared deep links for accessing both private events and tickets
- Redesigned Sherehe Details page to include start and end date for multi day events
- Fixed changes involving rsvping for a free event.
- Fixed fetching of All tickets and my tickets for an event error 