### PR TITLE
router: make route guards synchronous to prevent redirect race condition

### DIFF
--- a/lib/config/router/app_router.dart
+++ b/lib/config/router/app_router.dart
@@ -26,9 +26,9 @@ class AppRouter {
       DioRequestInspector.navigatorObserver,
     ],
     navigatorKey: globalNavigatorKey,
-    redirect: (context, state) async {
+    redirect: (context, state) {
       for (final guard in _guards) {
-        final String? redirectPath = await guard.check(context, state);
+        final String? redirectPath = guard.check(context, state);
 
         if (redirectPath != null) {
           return redirectPath;

--- a/lib/config/router/guards/account_recovery_guard.dart
+++ b/lib/config/router/guards/account_recovery_guard.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:academia/config/config.dart';
 import 'package:academia/config/router/route_guard.dart';
 import 'package:academia/features/features.dart';
@@ -10,7 +8,7 @@ import 'package:go_router/go_router.dart';
 class AccountRecoveryGuard implements RouteGuard {
   const AccountRecoveryGuard();
   @override
-  FutureOr<String?> check(BuildContext context, GoRouterState state) {
+  String? check(BuildContext context, GoRouterState state) {
     final profileState = context.read<ProfileBloc>().state;
 
     if (profileState is ProfileLoadedState) {

--- a/lib/config/router/guards/auth_guard.dart
+++ b/lib/config/router/guards/auth_guard.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:academia/config/config.dart';
 import 'package:academia/config/router/route_guard.dart';
 import 'package:academia/features/features.dart';
@@ -10,7 +8,7 @@ import 'package:go_router/go_router.dart';
 class AuthGuard implements RouteGuard {
   const AuthGuard();
   @override
-  FutureOr<String?> check(BuildContext context, GoRouterState state) {
+  String? check(BuildContext context, GoRouterState state) {
     final authState = context.read<AuthBloc>().state;
 
     // Define which location represents the "Entry Point"

--- a/lib/config/router/guards/onboarding_guard.dart
+++ b/lib/config/router/guards/onboarding_guard.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:academia/config/config.dart';
 import 'package:academia/config/router/route_guard.dart';
 import 'package:academia/features/features.dart';
@@ -10,7 +8,7 @@ import 'package:go_router/go_router.dart';
 class OnboardingGuard implements RouteGuard {
   const OnboardingGuard();
   @override
-  FutureOr<String?> check(BuildContext context, GoRouterState state) {
+  String? check(BuildContext context, GoRouterState state) {
     final profileState = context.read<ProfileBloc>().state;
 
     if (profileState is ProfileLoadedState) {

--- a/lib/config/router/route_guard.dart
+++ b/lib/config/router/route_guard.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
@@ -19,7 +18,7 @@ abstract class RouteGuard {
   /// * [state]: The current [GoRouterState], containing the location and parameters.
   ///
   /// Returns:
-  /// * `FutureOr<String?>`: A String representing the redirect path (e.g., '/login').
+  /// * String: A String representing the redirect path (e.g., '/login').
   /// * Returns `null` if the guard passes and the user is allowed to proceed.
   ///
   /// Example:
@@ -27,5 +26,5 @@ abstract class RouteGuard {
   /// if (notLoggedIn) return '/login';
   /// return null;
   /// ```
-  FutureOr<String?> check(BuildContext context, GoRouterState state);
+  String? check(BuildContext context, GoRouterState state);
 }


### PR DESCRIPTION
Async/await in the redirect pipeline was creating microtask gaps between each guard evaluation. These gaps allowed go_router's pop handler to complete an imperative route's Completer before the redirect pipeline finished, triggering 'Bad state: Future already completed' on any context.pop(result) call.

Drop FutureOr<String?> from RouteGuard in favour of String? since all guard implementations were synchronous to begin with. The redirect callback no longer needs to be async.